### PR TITLE
fix: workflow runコマンドの重複するissue取得APIコールを削減 (#39)

### DIFF
--- a/lib/soba/commands/workflow/run.rb
+++ b/lib/soba/commands/workflow/run.rb
@@ -65,8 +65,8 @@ module Soba
               issues = issue_watcher.fetch_issues
 
               # Check if workflow is blocked by other soba labels
-              if blocking_checker.blocking?(repository)
-                blocking_reason = blocking_checker.blocking_reason(repository)
+              if blocking_checker.blocking?(repository, issues: issues)
+                blocking_reason = blocking_checker.blocking_reason(repository, issues: issues)
                 puts "\n#{blocking_reason}"
                 sleep(interval) if @running
                 next

--- a/lib/soba/services/workflow_blocking_checker.rb
+++ b/lib/soba/services/workflow_blocking_checker.rb
@@ -19,50 +19,33 @@ module Soba
         @logger = logger || Logger.new(STDOUT)
       end
 
-      def blocking?(repository)
-        !blocking_issues(repository).empty?
+      def blocking?(repository, issues:)
+        !blocking_issues(repository, issues: issues).empty?
       end
 
-      def blocking_issues(repository)
-        # すべてのOpenなIssueを取得して、soba:*ラベル（soba:todoを除く）を持つものを検出
-        all_issues = []
-
-        begin
-          # まず、全てのopenなissueを取得
-          open_issues = github_client.issues(repository, state: "open")
-
-          # soba:で始まるラベル（soba:todoを除く）を持つissueをフィルタリング
-          blocking = open_issues.select do |issue|
-            issue.labels.any? do |label|
-              label_name = label.is_a?(Hash) ? label[:name] : label.name
-              label_name.start_with?("soba:") && label_name != "soba:todo"
-            end
+      def blocking_issues(repository, issues:)
+        # 引数で渡されたissuesからsoba:*ラベル（soba:todoを除く）を持つものを検出
+        blocking = issues.select do |issue|
+          issue.labels.any? do |label|
+            label_name = label.is_a?(Hash) ? label[:name] : label.name
+            label_name.start_with?("soba:") && label_name != "soba:todo"
           end
-
-          logger&.debug("Found #{blocking.size} blocking issues with soba:* labels")
-          blocking.each do |issue|
-            labels = issue.labels.map { |l| l.is_a?(Hash) ? l[:name] : l.name }.select { |n| n.start_with?("soba:") }
-            logger&.debug("Issue ##{issue.number}: #{labels.join(', ')}")
-          end
-
-          all_issues.concat(blocking)
-        rescue StandardError => e
-          # エラー時はログを出力して、安全側（ブロックする側）に倒す
-          logger&.error("Error fetching issues: #{e.message}")
-          logger&.error("Assuming blocking state for safety")
-          # エラー時は空配列を返さず、ダミーのブロッキング状態を示す
-          # ただし、既存のテストとの互換性のため、空配列を返す
-          # TODO: 将来的にはエラー時の挙動を明確化
         end
 
-        all_issues.compact.uniq { |issue| issue.number }
+        logger&.debug("Found #{blocking.size} blocking issues with soba:* labels")
+        blocking.each do |issue|
+          labels = issue.labels.map { |l| l.is_a?(Hash) ? l[:name] : l.name }.select { |n| n.start_with?("soba:") }
+          logger&.debug("Issue ##{issue.number}: #{labels.join(', ')}")
+        end
+
+        blocking.compact.uniq { |issue| issue.number }
       end
 
-      def blocking_reason(repository)
-        issues = blocking_issues(repository)
-        return nil if issues.empty?
+      def blocking_reason(repository, issues:)
+        blocking = blocking_issues(repository, issues: issues)
+        return nil if blocking.empty?
 
-        issue = issues.first
+        issue = blocking.first
         label = issue.labels.find do |l|
           label_name = l.is_a?(Hash) ? l[:name] : l.name
           label_name.start_with?("soba:")

--- a/spec/commands/workflow/run_spec.rb
+++ b/spec/commands/workflow/run_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe Soba::Commands::Workflow::Run do
       before do
         allow(github_client).to receive(:issues).and_return(issues_with_todo)
         allow(Soba::Services::WorkflowBlockingChecker).to receive(:new).and_return(blocking_checker)
-        allow(blocking_checker).to receive(:blocking?).with('owner/repo').and_return(false)
+        allow(blocking_checker).to receive(:blocking?).with('owner/repo', issues: issues_with_todo).and_return(false)
       end
 
       it 'updates label and executes workflow' do
@@ -107,7 +107,7 @@ RSpec.describe Soba::Commands::Workflow::Run do
       before do
         allow(github_client).to receive(:issues).and_return(issues_with_ready)
         allow(Soba::Services::WorkflowBlockingChecker).to receive(:new).and_return(blocking_checker)
-        allow(blocking_checker).to receive(:blocking?).with('owner/repo').and_return(false)
+        allow(blocking_checker).to receive(:blocking?).with('owner/repo', issues: issues_with_ready).and_return(false)
       end
 
       it 'updates label and executes workflow' do
@@ -152,8 +152,8 @@ RSpec.describe Soba::Commands::Workflow::Run do
       before do
         allow(github_client).to receive(:issues).and_return(issues_in_progress)
         allow(Soba::Services::WorkflowBlockingChecker).to receive(:new).and_return(blocking_checker)
-        allow(blocking_checker).to receive(:blocking?).with('owner/repo').and_return(true)
-        allow(blocking_checker).to receive(:blocking_reason).with('owner/repo').
+        allow(blocking_checker).to receive(:blocking?).with('owner/repo', issues: issues_in_progress).and_return(true)
+        allow(blocking_checker).to receive(:blocking_reason).with('owner/repo', issues: issues_in_progress).
           and_return('Issue #4 が soba:planning のため、新しいワークフローの開始をスキップしました')
       end
 
@@ -184,7 +184,7 @@ RSpec.describe Soba::Commands::Workflow::Run do
       before do
         allow(github_client).to receive(:issues).and_return(issues)
         allow(Soba::Services::WorkflowBlockingChecker).to receive(:new).and_return(blocking_checker)
-        allow(blocking_checker).to receive(:blocking?).with('owner/repo').and_return(false)
+        allow(blocking_checker).to receive(:blocking?).with('owner/repo', issues: issues).and_return(false)
         Soba::Configuration.configure do |c|
           c.phase.plan.command = nil
         end
@@ -227,8 +227,8 @@ RSpec.describe Soba::Commands::Workflow::Run do
         before do
           allow(github_client).to receive(:issues).and_return([todo_issue, review_issue])
           allow(Soba::Services::WorkflowBlockingChecker).to receive(:new).and_return(blocking_checker)
-          allow(blocking_checker).to receive(:blocking?).with('owner/repo').and_return(true)
-          allow(blocking_checker).to receive(:blocking_reason).with('owner/repo').
+          allow(blocking_checker).to receive(:blocking?).with('owner/repo', issues: [todo_issue, review_issue]).and_return(true)
+          allow(blocking_checker).to receive(:blocking_reason).with('owner/repo', issues: [todo_issue, review_issue]).
             and_return('Issue #21 が soba:review-requested のため、新しいワークフローの開始をスキップしました')
         end
 
@@ -267,8 +267,8 @@ RSpec.describe Soba::Commands::Workflow::Run do
         before do
           allow(github_client).to receive(:issues).and_return([todo_issue, doing_issue])
           allow(Soba::Services::WorkflowBlockingChecker).to receive(:new).and_return(blocking_checker)
-          allow(blocking_checker).to receive(:blocking?).with('owner/repo').and_return(true)
-          allow(blocking_checker).to receive(:blocking_reason).with('owner/repo').
+          allow(blocking_checker).to receive(:blocking?).with('owner/repo', issues: [todo_issue, doing_issue]).and_return(true)
+          allow(blocking_checker).to receive(:blocking_reason).with('owner/repo', issues: [todo_issue, doing_issue]).
             and_return('Issue #31 が soba:doing のため、新しいワークフローの開始をスキップしました')
         end
 
@@ -299,7 +299,7 @@ RSpec.describe Soba::Commands::Workflow::Run do
       before do
         allow(github_client).to receive(:issues).and_return([todo_issue])
         allow(Soba::Services::WorkflowBlockingChecker).to receive(:new).and_return(blocking_checker)
-        allow(blocking_checker).to receive(:blocking?).with('owner/repo').and_return(false)
+        allow(blocking_checker).to receive(:blocking?).with('owner/repo', issues: [todo_issue]).and_return(false)
       end
 
       it 'processes todo issues normally' do
@@ -337,7 +337,7 @@ RSpec.describe Soba::Commands::Workflow::Run do
       before do
         allow(github_client).to receive(:issues).and_return([todo_issue])
         allow(Soba::Services::WorkflowBlockingChecker).to receive(:new).and_return(blocking_checker)
-        allow(blocking_checker).to receive(:blocking?).with('owner/repo').and_return(false)
+        allow(blocking_checker).to receive(:blocking?).with('owner/repo', issues: [todo_issue]).and_return(false)
         allow(Soba::Services::TmuxSessionManager).to receive(:new).and_return(tmux_session_manager)
         allow(Soba::Services::WorkflowExecutor).to receive(:new).and_return(workflow_executor)
         allow(Soba::Services::IssueProcessor).to receive(:new).and_return(issue_processor)


### PR DESCRIPTION
## 実装完了

fixes #39

### 変更内容

- WorkflowBlockingCheckerのメソッドシグネチャを変更し、外部からissuesデータを受け取れるようにしました
  - `blocking?(repository, issues:)`
  - `blocking_issues(repository, issues:)`
  - `blocking_reason(repository, issues:)`
- workflow/run.rbで取得したissuesをblocking_checkerに渡すように修正
- 全テスト（374 examples）をパス

### パフォーマンス改善

APIコール回数の削減効果を確認：
- **変更前**: issue取得APIが2回呼ばれる（IssueWatcher用とBlockingChecker用）
- **変更後**: issue取得APIが1回のみ（50%削減）

### テスト結果
- 単体テスト: ✅ パス（374 examples, 0 failures）
- 全体テスト: ✅ パス

### 確認事項
- [x] 実装計画に沿った実装
- [x] テストカバレッジ確保
- [x] 既存機能への影響なし
- [x] APIコール削減の効果を確認