### PR TITLE
feat: PhaseStrategyの新ラベル体系対応 (#48)

### DIFF
--- a/lib/soba/domain/phase_strategy.rb
+++ b/lib/soba/domain/phase_strategy.rb
@@ -4,7 +4,8 @@ module Soba
   module Domain
     class PhaseStrategy
       PHASE_TRANSITIONS = {
-        'soba:todo' => 'soba:planning',
+        'soba:todo' => 'soba:queued',
+        'soba:queued' => 'soba:planning',
         'soba:planning' => 'soba:ready',
         'soba:ready' => 'soba:doing',
         'soba:doing' => 'soba:review-requested',
@@ -17,7 +18,7 @@ module Soba
         review: { current: 'soba:review-requested', next: 'soba:reviewing' },
       }.freeze
 
-      IN_PROGRESS_LABELS = %w(soba:planning soba:doing soba:reviewing).freeze
+      IN_PROGRESS_LABELS = %w(soba:queued soba:planning soba:doing soba:reviewing).freeze
 
       def determine_phase(labels)
         return nil if labels.blank?
@@ -52,6 +53,11 @@ module Soba
 
         if !from_label.start_with?('soba:') || !to_label.start_with?('soba:')
           return false
+        end
+
+        # Allow direct transition from soba:todo to soba:planning (legacy path)
+        if from_label == 'soba:todo' && to_label == 'soba:planning'
+          return true
         end
 
         PHASE_TRANSITIONS[from_label] == to_label

--- a/spec/domain/phase_strategy_spec.rb
+++ b/spec/domain/phase_strategy_spec.rb
@@ -37,6 +37,16 @@ RSpec.describe Soba::Domain::PhaseStrategy do
       end
     end
 
+    context 'when issue has soba:queued label' do
+      let(:labels) { ['soba:queued'] }
+
+      it 'returns nil (already in progress)' do
+        phase = strategy.determine_phase(labels)
+
+        expect(phase).to be_nil
+      end
+    end
+
     context 'when issue has soba:planning label' do
       let(:labels) { ['soba:planning'] }
 
@@ -141,6 +151,22 @@ RSpec.describe Soba::Domain::PhaseStrategy do
   end
 
   describe '#validate_transition' do
+    context 'from soba:todo to soba:queued' do
+      it 'returns true' do
+        result = strategy.validate_transition('soba:todo', 'soba:queued')
+
+        expect(result).to be true
+      end
+    end
+
+    context 'from soba:queued to soba:planning' do
+      it 'returns true' do
+        result = strategy.validate_transition('soba:queued', 'soba:planning')
+
+        expect(result).to be true
+      end
+    end
+
     context 'from soba:todo to soba:planning' do
       it 'returns true' do
         result = strategy.validate_transition('soba:todo', 'soba:planning')


### PR DESCRIPTION
## 実装完了

fixes #48

### 変更内容
- **PHASE_TRANSITIONSの更新**: `soba:todo` → `soba:queued` → `soba:planning` の新しい遷移パターンを追加
- **IN_PROGRESS_LABELSの更新**: `soba:queued`を進行中ラベルとして追加し、排他制御の対象に含めました
- **validate_transitionメソッドの改善**: 新しいキューイング経路と既存の直接遷移の両方をサポートする柔軟な実装に更新
- **包括的なテストケースの追加**: 新しいラベル遷移パターンのテストを追加し、既存の機能との互換性を確保

### テスト結果
- 単体テスト: ✅ パス (30 examples, 0 failures)
- 全体テスト: ✅ パス (401 examples, 0 failures, 11 pending)
- RuboCop: ✅ パス (no offenses detected)

### 技術的な詳細
新しいキューイングシステムに対応するため、PhaseStrategyクラスを以下のように拡張しました：

1. `soba:queued`ラベルを進行中ラベル（IN_PROGRESS_LABELS）に追加
2. `soba:todo` → `soba:queued` → `soba:planning`の新しい遷移パスを定義
3. 後方互換性のため、`soba:todo` → `soba:planning`の直接遷移も維持

これにより、WorkflowBlockingCheckerと連携した厳密な排他制御が可能になります。

### 確認事項
- [x] 実装計画に沿った実装
- [x] テストカバレッジ確保
- [x] 既存機能への影響なし
- [x] TDD（テストファースト開発）の実践
- [x] コード品質の確保（RuboCop準拠）