### PR TITLE
feat: tmuxペイン管理の改善（水平分割、ペイン数制限、自動レイアウト） (#59)

### DIFF
--- a/docs/development/tmux-management.md
+++ b/docs/development/tmux-management.md
@@ -60,6 +60,23 @@ soba-claude-{issue_number}-{timestamp}
 - `split_pane`: ペインの分割（水平/垂直）
 - `resize_pane`: ペインサイズ調整
 - `select_pane`: アクティブペインの切り替え
+- `list_panes`: ペイン一覧と作成時刻の取得
+- `kill_pane`: 指定ペインの削除
+- `select_layout`: レイアウトの自動調整
+
+### ペイン管理の自動化
+
+#### ペイン数制限機能
+フェーズ実行時に自動的にペイン数を管理：
+- **最大ペイン数**: デフォルトで3つに制限
+- **自動削除**: 4つ目のペイン作成時に最古のペインを自動削除
+- **作成時刻追跡**: `#{pane_start_time}`フォーマットを使用
+
+#### レイアウト自動調整
+ペイン作成・削除後に自動的にレイアウトを調整：
+- **水平分割**: フェーズ実行時のデフォルト（`vertical: false`）
+- **自動調整**: `even-horizontal`レイアウトを適用
+- **均等配置**: すべてのペインが同じ幅になるよう調整
 
 ### 自動クリーンアップ
 
@@ -118,6 +135,33 @@ end
 sessions.each do |session|
   status = manager.get_session_status(session)
   puts "#{session}: #{status[:status]}"
+end
+```
+
+### フェーズごとのペイン管理
+
+```ruby
+# リポジトリセッションとIssueウィンドウの作成
+session_result = manager.find_or_create_repository_session
+window_result = manager.create_issue_window(
+  session_name: session_result[:session_name],
+  issue_number: 42
+)
+
+# フェーズごとにペインを作成（水平分割、最大3ペイン）
+phases = ['planning', 'implementation', 'review', 'testing']
+phases.each do |phase|
+  pane_result = manager.create_phase_pane(
+    session_name: session_result[:session_name],
+    window_name: window_result[:window_name],
+    phase: phase,
+    vertical: false,  # 水平分割
+    max_panes: 3     # 最大3ペイン（4つ目から古いペインを削除）
+  )
+
+  if pane_result[:success]
+    puts "Phase #{phase} started in pane #{pane_result[:pane_id]}"
+  end
 end
 ```
 

--- a/lib/soba/infrastructure/tmux_client.rb
+++ b/lib/soba/infrastructure/tmux_client.rb
@@ -207,6 +207,36 @@ module Soba
         nil
       end
 
+      def list_panes(session_name, window_name)
+        target = "#{session_name}:#{window_name}"
+        stdout, _stderr, status = execute_tmux_command(
+          'list-panes', '-t', target, '-F', '#{pane_id}:#{pane_start_time}'
+        )
+        return [] unless status.exitstatus == 0
+
+        stdout.lines.map do |line|
+          parts = line.strip.split(':')
+          { id: parts[0], start_time: parts[1].to_i }
+        end
+      rescue Errno::ENOENT
+        []
+      end
+
+      def kill_pane(pane_id)
+        _stdout, _stderr, status = execute_tmux_command('kill-pane', '-t', pane_id)
+        status.exitstatus == 0
+      rescue Errno::ENOENT
+        false
+      end
+
+      def select_layout(session_name, window_name, layout)
+        target = "#{session_name}:#{window_name}"
+        _stdout, _stderr, status = execute_tmux_command('select-layout', '-t', target, layout)
+        status.exitstatus == 0
+      rescue Errno::ENOENT
+        false
+      end
+
       private
 
       def execute_tmux_command(*args)

--- a/lib/soba/services/workflow_executor.rb
+++ b/lib/soba/services/workflow_executor.rb
@@ -93,11 +93,12 @@ module Soba
             tmux_client.send_keys("#{session_result[:session_name]}:#{window_result[:window_name]}", command_string)
             pane_id = nil
           else
-            # 既存windowの場合は新規paneを作成
+            # 既存windowの場合は新規paneを作成（水平分割）
             pane_result = @tmux_session_manager.create_phase_pane(
               session_name: session_result[:session_name],
               window_name: window_result[:window_name],
-              phase: phase.name
+              phase: phase.name,
+              vertical: false
             )
             return pane_result unless pane_result[:success]
 

--- a/spec/integration/workflow_tmux_spec.rb
+++ b/spec/integration/workflow_tmux_spec.rb
@@ -74,11 +74,13 @@ RSpec.describe 'Workflow Tmux Integration' do
         allow(tmux_client).to receive(:create_window) # Allow but don't expect
 
         # Create new pane for the phase
+        allow(tmux_client).to receive(:list_panes).with('soba-owner-repo-name', 'issue-42').and_return([])
         allow(tmux_client).to receive(:split_window).with(
           session_name: 'soba-owner-repo-name',
           window_name: 'issue-42',
-          vertical: true
+          vertical: false
         ).and_return('%15')
+        allow(tmux_client).to receive(:select_layout).with('soba-owner-repo-name', 'issue-42', 'even-horizontal').and_return(true)
 
         # Send command to the new pane
         allow(tmux_client).to receive(:send_keys).with('%15', 'soba:plan 42').and_return(true)
@@ -151,11 +153,13 @@ RSpec.describe 'Workflow Tmux Integration' do
         allow(tmux_client).to receive(:send_keys).with('soba-owner-repo-name:issue-31', 'soba:plan 31').and_return(true)
 
         # Second phase: window exists, create new pane
+        allow(tmux_client).to receive(:list_panes).with('soba-owner-repo-name', 'issue-31').and_return([])
         allow(tmux_client).to receive(:split_window).with(
           session_name: 'soba-owner-repo-name',
           window_name: 'issue-31',
-          vertical: true
+          vertical: false
         ).and_return('%20')
+        allow(tmux_client).to receive(:select_layout).with('soba-owner-repo-name', 'issue-31', 'even-horizontal').and_return(true)
         allow(tmux_client).to receive(:send_keys).with('%20', 'soba:implement 31').and_return(true)
       end
 


### PR DESCRIPTION
## 実装完了

fixes #59

### 変更内容

#### TmuxClient拡張
- `list_panes`: ペイン一覧と作成時刻を取得するメソッドを追加
- `kill_pane`: 指定ペインIDを削除するメソッドを追加
- `select_layout`: ウィンドウのレイアウトを調整するメソッドを追加

#### TmuxSessionManager改善
- `create_phase_pane`メソッドを拡張
  - 最大ペイン数制限機能（デフォルト3つ）
  - 4つ目のペイン作成時に最古のペインを自動削除
  - ペイン作成後に`even-horizontal`レイアウトを自動適用

#### WorkflowExecutor修正
- フェーズ実行時のペイン作成を水平分割（`vertical: false`）に変更
- より見やすいログ表示を実現

### テスト結果
- 単体テスト: ✅ パス
  - TmuxClient: 新規メソッドの動作確認
  - TmuxSessionManager: ペイン管理機能の動作確認
- 統合テスト: ✅ パス
  - ペイン数制限の動作確認
  - レイアウト自動調整の確認
- 全体テスト: ✅ パス（406 examples, 0 failures）

### ドキュメント
- `/docs/development/tmux-management.md`を更新
  - ペイン管理の自動化機能を追記
  - 使用例を追加

### 確認事項
- [x] 実装計画に沿った実装
- [x] テストカバレッジ確保
- [x] 既存機能への影響なし
- [x] RuboCopによる静的解析パス