### PR TITLE
fix: Octokit 8.x APIの引数エラーを修正

### DIFF
--- a/lib/soba/infrastructure/github_client.rb
+++ b/lib/soba/infrastructure/github_client.rb
@@ -196,7 +196,7 @@ module Soba
 
         response = with_error_handling do
           with_rate_limit_check do
-            @octokit.merge_pull_request(repository, pr_number, nil, merge_method: merge_method)
+            @octokit.merge_pull_request(repository, pr_number, "", merge_method: merge_method)
           end
         end
 


### PR DESCRIPTION
## 概要

PR #66 をマージしようとした際に発生した「wrong number of arguments (given 1, expected 0)」エラーを修正します。

## 問題

`Octokit::Client#merge_pull_request` メソッドを呼び出す際、3番目の引数に `nil` を渡していましたが、Octokit 8.x では引数の扱いが変更されており、これがエラーの原因となっていました。

## 解決策

3番目の引数（commit_message）に空文字列 `""` を渡すように変更しました。これによりOctokit 8.xのAPIシグネチャに適合します。

```ruby
# 修正前
@octokit.merge_pull_request(repository, pr_number, nil, merge_method: merge_method)

# 修正後
@octokit.merge_pull_request(repository, pr_number, "", merge_method: merge_method)
```

## テスト

- ✅ 全テスト合格を確認
- ✅ PR #66 がマージ可能な状態であることを確認

## 関連するPR

- #66 - この修正により、正常にマージ可能になります

🤖 Generated with [Claude Code](https://claude.ai/code)