### PR TITLE
fix: ワークフローラベルの排他制御実装 (#65)

### DIFF
--- a/lib/soba/services/workflow_integrity_checker.rb
+++ b/lib/soba/services/workflow_integrity_checker.rb
@@ -1,0 +1,150 @@
+# frozen_string_literal: true
+
+require "logger"
+
+module Soba
+  module Services
+    class WorkflowIntegrityChecker
+      ACTIVE_LABELS = %w(
+        soba:queued
+        soba:planning
+        soba:doing
+        soba:reviewing
+        soba:revising
+      ).freeze
+
+      INTERMEDIATE_LABELS = %w(
+        soba:review-requested
+        soba:requires-changes
+      ).freeze
+
+      attr_reader :github_client, :logger
+
+      def initialize(github_client:, logger: nil)
+        @github_client = github_client
+        @logger = logger || Logger.new(STDOUT)
+      end
+
+      def check_and_fix(repository, issues:, dry_run: false)
+        logger.info("Checking workflow integrity for #{repository}")
+
+        violations = detect_violations(issues)
+
+        if violations.empty?
+          logger.info("No workflow integrity violations found")
+          return {
+            violations_found: false,
+            fixed_count: 0,
+            violations: [],
+            dry_run: dry_run,
+          }
+        end
+
+        logger.warn("Found #{violations.size} workflow integrity violations")
+        violations.each do |violation|
+          logger.warn("  Issue ##{violation[:issue_number]}: #{violation[:label]} (#{violation[:action]})")
+        end
+
+        fixed_count = 0
+        failed_fixes = 0
+
+        if dry_run
+          logger.info("Dry run mode - no fixes applied")
+        else
+          violations.each do |violation|
+            if fix_violation(violation)
+              fixed_count += 1
+            else
+              failed_fixes += 1
+            end
+          end
+          if fixed_count > 0 || failed_fixes > 0
+            logger.info("Fixed #{fixed_count} violations, #{failed_fixes} failed")
+          end
+        end
+
+        {
+          violations_found: true,
+          fixed_count: fixed_count,
+          failed_fixes: failed_fixes,
+          violations: violations,
+          dry_run: dry_run,
+        }
+      end
+
+      private
+
+      def detect_violations(issues)
+        violations = []
+
+        # Find all issues with active or intermediate labels
+        active_issues = issues.select do |issue|
+          labels = extract_label_names(issue.labels)
+          (labels & (ACTIVE_LABELS + INTERMEDIATE_LABELS)).any?
+        end
+
+        return violations if active_issues.size <= 1
+
+        # Multiple active issues detected - keep only the newest
+        # Sort by created_at descending (newest first)
+        sorted_issues = active_issues.sort_by { |issue| issue.created_at }.reverse
+        newest_issue = sorted_issues.first
+
+        # Mark all others as violations
+        sorted_issues[1..-1].each do |issue|
+          labels = extract_label_names(issue.labels)
+          conflicting_label = labels.find { |l| (ACTIVE_LABELS + INTERMEDIATE_LABELS).include?(l) }
+
+          violations << {
+            issue_number: issue.number,
+            label: conflicting_label,
+            action: "removed",
+            reason: "Multiple active issues detected, keeping newest (Issue ##{newest_issue.number})",
+          }
+        end
+
+        violations
+      end
+
+      def fix_violation(violation)
+        logger.info("Fixing violation: Issue ##{violation[:issue_number]} - removing #{violation[:label]}")
+
+        # Determine the target label based on what's being removed
+        target_label = determine_target_label(violation[:label])
+
+        github_client.update_issue_labels(
+          violation[:issue_number],
+          from: violation[:label],
+          to: target_label
+        )
+
+        logger.info("Successfully fixed Issue ##{violation[:issue_number]}")
+        true
+      rescue => e
+        logger.error("Failed to fix violation for Issue ##{violation[:issue_number]}: #{e.message}")
+        false
+      end
+
+      def determine_target_label(from_label)
+        # Most labels should revert to todo
+        # Special cases can be handled here if needed
+        case from_label
+        when "soba:review-requested", "soba:requires-changes"
+          "soba:ready"  # Review states go back to ready
+        else
+          "soba:todo"   # Active states go back to todo
+        end
+      end
+
+      def extract_label_names(labels)
+        labels.map do |label|
+          if label.is_a?(Hash)
+            label[:name] || label["name"]
+          else
+            label.name
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/services/workflow_blocking_checker_spec.rb
+++ b/spec/services/workflow_blocking_checker_spec.rb
@@ -154,9 +154,41 @@ RSpec.describe Soba::Services::WorkflowBlockingChecker do
       end
       let(:issues) { [review_issue] }
 
-      it "returns false" do
+      it "returns true (intermediate state blocks new issues)" do
         result = checker.blocking?(repository, issues: issues)
-        expect(result).to be false
+        expect(result).to be true
+      end
+    end
+
+    context "when soba:requires-changes issue exists" do
+      let(:requires_changes_issue) do
+        double(
+          number: 7,
+          title: "Requires Changes Issue",
+          labels: [{ name: "soba:requires-changes" }]
+        )
+      end
+      let(:issues) { [requires_changes_issue] }
+
+      it "returns true (intermediate state blocks new issues)" do
+        result = checker.blocking?(repository, issues: issues)
+        expect(result).to be true
+      end
+    end
+
+    context "when soba:revising issue exists" do
+      let(:revising_issue) do
+        double(
+          number: 8,
+          title: "Revising Issue",
+          labels: [{ name: "soba:revising" }]
+        )
+      end
+      let(:issues) { [revising_issue] }
+
+      it "returns true (active state blocks new issues)" do
+        result = checker.blocking?(repository, issues: issues)
+        expect(result).to be true
       end
     end
 
@@ -242,9 +274,9 @@ RSpec.describe Soba::Services::WorkflowBlockingChecker do
       end
       let(:issues) { [ready_issue, review_requested_issue] }
 
-      it "returns false when only WAITING_LABELS are present" do
+      it "returns true when review-requested is present (intermediate state)" do
         result = checker.blocking?(repository, issues: issues)
-        expect(result).to be false
+        expect(result).to be true
       end
     end
 

--- a/spec/services/workflow_integrity_checker_spec.rb
+++ b/spec/services/workflow_integrity_checker_spec.rb
@@ -1,0 +1,259 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "soba/services/workflow_integrity_checker"
+
+RSpec.describe Soba::Services::WorkflowIntegrityChecker do
+  let(:github_client) { instance_double(Soba::Infrastructure::GitHubClient) }
+  let(:logger) { instance_double(Logger) }
+  let(:checker) { described_class.new(github_client: github_client, logger: logger) }
+  let(:repository) { "owner/repo" }
+
+  before do
+    allow(logger).to receive(:info)
+    allow(logger).to receive(:warn)
+    allow(logger).to receive(:error)
+  end
+
+  describe "#check_and_fix" do
+    context "when no active issues exist" do
+      let(:issues) { [] }
+
+      it "returns result with no violations" do
+        result = checker.check_and_fix(repository, issues: issues)
+
+        expect(result[:violations_found]).to be false
+        expect(result[:fixed_count]).to eq(0)
+        expect(result[:violations]).to be_empty
+      end
+    end
+
+    context "when single active issue exists" do
+      let(:issue) do
+        instance_double(
+          Soba::Domain::Issue,
+          number: 1,
+          title: "Active Issue",
+          labels: [{ name: "soba:planning" }]
+        )
+      end
+      let(:issues) { [issue] }
+
+      it "returns result with no violations" do
+        result = checker.check_and_fix(repository, issues: issues)
+
+        expect(result[:violations_found]).to be false
+        expect(result[:fixed_count]).to eq(0)
+      end
+    end
+
+    context "when multiple active issues exist" do
+      let(:older_issue) do
+        instance_double(
+          Soba::Domain::Issue,
+          number: 1,
+          title: "Older Issue",
+          labels: [{ name: "soba:planning" }],
+          created_at: Time.now - 3600
+        )
+      end
+
+      let(:newer_issue) do
+        instance_double(
+          Soba::Domain::Issue,
+          number: 2,
+          title: "Newer Issue",
+          labels: [{ name: "soba:doing" }],
+          created_at: Time.now - 1800
+        )
+      end
+
+      let(:issues) { [older_issue, newer_issue] }
+
+      before do
+        allow(github_client).to receive(:update_issue_labels)
+      end
+
+      it "detects violations and fixes by keeping newest issue active" do
+        result = checker.check_and_fix(repository, issues: issues)
+
+        expect(result[:violations_found]).to be true
+        expect(result[:fixed_count]).to eq(1)
+        expect(result[:violations]).to include(
+          hash_including(
+            issue_number: 1,
+            label: "soba:planning",
+            action: "removed"
+          )
+        )
+
+        expect(github_client).to have_received(:update_issue_labels).with(
+          1,
+          from: "soba:planning",
+          to: "soba:todo"
+        )
+      end
+    end
+
+    context "when multiple issues with same active label exist" do
+      let(:issue1) do
+        instance_double(
+          Soba::Domain::Issue,
+          number: 3,
+          title: "Issue 3",
+          labels: [{ name: "soba:queued" }],
+          created_at: Time.now - 1000
+        )
+      end
+
+      let(:issue2) do
+        instance_double(
+          Soba::Domain::Issue,
+          number: 5,
+          title: "Issue 5",
+          labels: [{ name: "soba:queued" }],
+          created_at: Time.now - 500
+        )
+      end
+
+      let(:issues) { [issue1, issue2] }
+
+      before do
+        allow(github_client).to receive(:update_issue_labels)
+      end
+
+      it "keeps the newest issue and reverts others" do
+        result = checker.check_and_fix(repository, issues: issues)
+
+        expect(result[:violations_found]).to be true
+        expect(result[:fixed_count]).to eq(1)
+
+        # Should revert the older issue (issue1)
+        expect(github_client).to have_received(:update_issue_labels).with(
+          3,
+          from: "soba:queued",
+          to: "soba:todo"
+        )
+      end
+    end
+
+    context "when intermediate state issues conflict with active issues" do
+      let(:active_issue) do
+        instance_double(
+          Soba::Domain::Issue,
+          number: 10,
+          title: "Active Issue",
+          labels: [{ name: "soba:doing" }],
+          created_at: Time.now - 1000
+        )
+      end
+
+      let(:intermediate_issue) do
+        instance_double(
+          Soba::Domain::Issue,
+          number: 11,
+          title: "Intermediate Issue",
+          labels: [{ name: "soba:review-requested" }],
+          created_at: Time.now - 500
+        )
+      end
+
+      let(:issues) { [active_issue, intermediate_issue] }
+
+      before do
+        allow(github_client).to receive(:update_issue_labels)
+      end
+
+      it "keeps the newest issue regardless of state type" do
+        result = checker.check_and_fix(repository, issues: issues)
+
+        expect(result[:violations_found]).to be true
+        expect(result[:fixed_count]).to eq(1)
+
+        # Should revert the older active issue since intermediate is newer
+        expect(github_client).to have_received(:update_issue_labels).with(
+          10,
+          from: "soba:doing",
+          to: "soba:todo"
+        )
+      end
+    end
+
+    context "when fix attempt fails" do
+      let(:issue1) do
+        instance_double(
+          Soba::Domain::Issue,
+          number: 20,
+          title: "Issue 20",
+          labels: [{ name: "soba:planning" }],
+          created_at: Time.now - 1000
+        )
+      end
+
+      let(:issue2) do
+        instance_double(
+          Soba::Domain::Issue,
+          number: 21,
+          title: "Issue 21",
+          labels: [{ name: "soba:doing" }],
+          created_at: Time.now - 500
+        )
+      end
+
+      let(:issues) { [issue1, issue2] }
+
+      before do
+        allow(github_client).to receive(:update_issue_labels).
+          and_raise(StandardError, "API Error")
+      end
+
+      it "logs error and continues with other fixes" do
+        result = checker.check_and_fix(repository, issues: issues)
+
+        expect(result[:violations_found]).to be true
+        expect(result[:fixed_count]).to eq(0)
+        expect(result[:failed_fixes]).to eq(1)
+        expect(logger).to have_received(:error).with(/Failed to fix violation/)
+      end
+    end
+
+    context "when dry_run mode is enabled" do
+      let(:issue1) do
+        instance_double(
+          Soba::Domain::Issue,
+          number: 30,
+          title: "Issue 30",
+          labels: [{ name: "soba:planning" }],
+          created_at: Time.now - 1000
+        )
+      end
+
+      let(:issue2) do
+        instance_double(
+          Soba::Domain::Issue,
+          number: 31,
+          title: "Issue 31",
+          labels: [{ name: "soba:doing" }],
+          created_at: Time.now - 500
+        )
+      end
+
+      let(:issues) { [issue1, issue2] }
+
+      before do
+        allow(github_client).to receive(:update_issue_labels)  # スパイとして設定
+      end
+
+      it "detects violations but does not fix them" do
+        result = checker.check_and_fix(repository, issues: issues, dry_run: true)
+
+        expect(result[:violations_found]).to be true
+        expect(result[:fixed_count]).to eq(0)
+        expect(result[:dry_run]).to be true
+        expect(result[:violations]).not_to be_empty
+
+        expect(github_client).not_to have_received(:update_issue_labels)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 実装完了

fixes #65

### 変更内容

ワークフローラベルの排他制御機能を実装しました。複数のIssueが同時にアクティブ状態になることを防ぎ、ワークフローの整合性を保証します。

### 主な実装内容

1. **WorkflowBlockingCheckerの拡張**
   - `INTERMEDIATE_LABELS`（`soba:review-requested`、`soba:requires-changes`）を追加
   - `soba:revising`を`ACTIVE_LABELS`に追加
   - 中間状態ラベルも排他制御の対象に含めることでタイミング問題を解決

2. **QueueingServiceの排他制御強化**
   - `transition_to_queued`メソッドでラベル更新直前に再度排他制御チェック
   - 競合状態を検出した場合はキューイングをスキップ
   - 詳細なログ出力による状態の可視化

3. **GitHubClientにアトミックなラベル更新メソッド追加**
   - `update_issue_labels_with_check`メソッドを新規実装
   - 更新前に現在のラベル状態を検証
   - 期待する状態と異なる場合は更新をスキップ（楽観的ロック）

4. **ワークフロー実行時の排他制御チェック追加**
   - `workflow/run.rb`に複数アクティブIssue検出機能を追加
   - 競合が検出された場合は処理をスキップし、次のサイクルまで待機

5. **エラーリカバリー機能（WorkflowIntegrityChecker）の実装**
   - 不整合状態の検出機能（複数のアクティブIssue）
   - 最も新しいIssue以外のラベルを自動修正
   - ドライランモードのサポート

### テスト結果
- 単体テスト: ✅ パス（全325ケース）
- 全体テスト: ✅ パス
- RuboCop: ✅ パス

### 確認事項
- [x] 実装計画に沿った実装
- [x] テストカバレッジ確保
- [x] 既存機能への影響なし
- [x] 後方互換性の維持