### PR TITLE
feat: soba initコマンドにクローズドIssueクリーンアップ設定を追加 (#78)

### DIFF
--- a/lib/soba/commands/init.rb
+++ b/lib/soba/commands/init.rb
@@ -18,6 +18,8 @@ module Soba
         'workflow' => {
           'interval' => 20,
           'auto_merge_enabled' => true,
+          'closed_issue_cleanup_enabled' => true,
+          'closed_issue_cleanup_interval' => 300,
           'phase_labels' => {
             'planning' => 'soba:planning',
             'ready' => 'soba:ready',
@@ -327,6 +329,8 @@ module Soba
           'workflow' => {
             'interval' => interval,
             'auto_merge_enabled' => auto_merge_enabled,
+            'closed_issue_cleanup_enabled' => true,
+            'closed_issue_cleanup_interval' => 300,
             'phase_labels' => {
               'planning' => planning_label,
               'ready' => ready_label,
@@ -403,6 +407,12 @@ module Soba
 
             # Enable automatic merging of PRs with soba:lgtm label
             auto_merge_enabled: #{config['workflow']['auto_merge_enabled']}
+
+            # Enable automatic cleanup of tmux windows for closed issues
+            closed_issue_cleanup_enabled: #{config['workflow']['closed_issue_cleanup_enabled']}
+
+            # Cleanup check interval in seconds
+            closed_issue_cleanup_interval: #{config['workflow']['closed_issue_cleanup_interval']}
 
             # Phase labels for tracking issue progress
             phase_labels:

--- a/spec/commands/init_spec.rb
+++ b/spec/commands/init_spec.rb
@@ -39,6 +39,8 @@ RSpec.describe Soba::Commands::Init do
         expect(config['workflow']['phase_labels']['ready']).to eq('soba:ready')
         expect(config['workflow']['phase_labels']['doing']).to eq('soba:doing')
         expect(config['workflow']['phase_labels']['review_requested']).to eq('soba:review-requested')
+        expect(config['workflow']['closed_issue_cleanup_enabled']).to eq(true)
+        expect(config['workflow']['closed_issue_cleanup_interval']).to eq(300)
         expect(config['phase']).to be_nil
       end
 
@@ -52,6 +54,8 @@ RSpec.describe Soba::Commands::Init do
         config = YAML.safe_load_file(config_path)
         expect(config['github']['token']).to eq('secret_token')
         expect(config['workflow']['auto_merge_enabled']).to eq(true)
+        expect(config['workflow']['closed_issue_cleanup_enabled']).to eq(true)
+        expect(config['workflow']['closed_issue_cleanup_interval']).to eq(300)
       end
 
       it "accepts custom phase labels" do
@@ -67,6 +71,8 @@ RSpec.describe Soba::Commands::Init do
         expect(config['workflow']['phase_labels']['doing']).to eq('doing')
         expect(config['workflow']['phase_labels']['review_requested']).to eq('review')
         expect(config['workflow']['auto_merge_enabled']).to eq(true)
+        expect(config['workflow']['closed_issue_cleanup_enabled']).to eq(true)
+        expect(config['workflow']['closed_issue_cleanup_interval']).to eq(300)
       end
 
       it "accepts workflow phase commands" do
@@ -78,6 +84,8 @@ RSpec.describe Soba::Commands::Init do
 
         config = YAML.safe_load_file(config_path)
         expect(config['workflow']['auto_merge_enabled']).to eq(true)
+        expect(config['workflow']['closed_issue_cleanup_enabled']).to eq(true)
+        expect(config['workflow']['closed_issue_cleanup_interval']).to eq(300)
         expect(config['phase']['plan']['command']).to eq('claude')
         expect(config['phase']['plan']['options']).to eq(['--dangerously-skip-permissions'])
         expect(config['phase']['plan']['parameter']).to eq('/soba:plan {{issue-number}}')
@@ -102,6 +110,8 @@ RSpec.describe Soba::Commands::Init do
         # Check that config applies default values when Enter is pressed
         config = YAML.safe_load_file(config_path)
         expect(config['workflow']['auto_merge_enabled']).to eq(true)
+        expect(config['workflow']['closed_issue_cleanup_enabled']).to eq(true)
+        expect(config['workflow']['closed_issue_cleanup_interval']).to eq(300)
         expect(config['phase']['plan']['command']).to eq('claude')
         expect(config['phase']['plan']['options']).to eq(['--dangerously-skip-permissions'])
         expect(config['phase']['plan']['parameter']).to eq('/soba:plan {{issue-number}}')
@@ -124,6 +134,8 @@ RSpec.describe Soba::Commands::Init do
         config = YAML.safe_load_file(config_path)
         # phase設定が作成され、デフォルト値が適用されていることを確認
         expect(config['workflow']['auto_merge_enabled']).to eq(true)
+        expect(config['workflow']['closed_issue_cleanup_enabled']).to eq(true)
+        expect(config['workflow']['closed_issue_cleanup_interval']).to eq(300)
         expect(config['phase']).not_to be_nil
         expect(config['phase']['plan']['command']).to eq('claude')
         expect(config['phase']['plan']['options']).to eq(['--dangerously-skip-permissions'])
@@ -146,6 +158,8 @@ RSpec.describe Soba::Commands::Init do
 
         config = YAML.safe_load_file(config_path)
         expect(config['workflow']['auto_merge_enabled']).to eq(true)
+        expect(config['workflow']['closed_issue_cleanup_enabled']).to eq(true)
+        expect(config['workflow']['closed_issue_cleanup_interval']).to eq(300)
         expect(config['phase']['plan']['command']).to eq('custom-claude')
         expect(config['phase']['plan']['options']).to eq(['--dangerously-skip-permissions'])
         expect(config['phase']['plan']['parameter']).to eq('/soba:plan {{issue-number}}')
@@ -284,6 +298,8 @@ RSpec.describe Soba::Commands::Init do
         expect { command.execute }.to output(/Configuration created successfully/).to_stdout
 
         config = YAML.safe_load_file(config_path)
+        expect(config['workflow']['closed_issue_cleanup_enabled']).to eq(true)
+        expect(config['workflow']['closed_issue_cleanup_interval']).to eq(300)
         expect(config['phase']['plan']['command']).to eq('claude')
         expect(config['phase']['plan']['options']).to eq(['--dangerously-skip-permissions'])
         expect(config['phase']['plan']['parameter']).to eq('/soba:plan {{issue-number}}')
@@ -495,6 +511,8 @@ RSpec.describe Soba::Commands::Init do
         expect(config['workflow']['phase_labels']['ready']).to eq('soba:ready')
         expect(config['workflow']['phase_labels']['doing']).to eq('soba:doing')
         expect(config['workflow']['phase_labels']['review_requested']).to eq('soba:review-requested')
+        expect(config['workflow']['closed_issue_cleanup_enabled']).to eq(true)
+        expect(config['workflow']['closed_issue_cleanup_interval']).to eq(300)
 
         # Phase configuration should be present with default values
         expect(config['phase']).not_to be_nil


### PR DESCRIPTION
## 実装完了

fixes #78

### 変更内容
- `soba init`コマンドでクローズドIssueのtmuxウィンドウ自動クリーンアップ設定を出力するように更新
- DEFAULT_CONFIG定数に以下の設定を追加:
  - `closed_issue_cleanup_enabled`: デフォルトtrue
  - `closed_issue_cleanup_interval`: デフォルト300秒（5分）
- インタラクティブモード/非インタラクティブモードの両方で設定を含むように実装
- 設定ファイルの出力に適切な説明コメントを追加

### テスト結果
- 単体テスト: ✅ パス（`spec/commands/init_spec.rb`）
- 全体テスト: ✅ パス

### 確認事項
- [x] 実装計画に沿った実装
- [x] テストカバレッジ確保
- [x] 既存機能への影響なし
- [x] 設定項目に説明コメントが含まれる