### PR TITLE
refactor: tmuxセッション管理の簡素化とウィンドウ管理への移行

### DIFF
--- a/lib/soba/services/closed_issue_window_cleaner.rb
+++ b/lib/soba/services/closed_issue_window_cleaner.rb
@@ -14,16 +14,16 @@ module Soba
       end
 
       def clean(session_name)
-        logger.info('Cleaning up windows for closed issues...')
+        logger.debug("Cleaning up windows for closed issues in session: #{session_name}")
 
         begin
           closed_issues = fetch_closed_issues
           if closed_issues.empty?
-            logger.info('No closed issues found')
+            logger.debug('No closed issues found')
             return
           end
 
-          logger.info("Found #{closed_issues.size} closed issues")
+          logger.debug("Found #{closed_issues.size} closed issues")
 
           windows = list_tmux_windows(session_name)
           return if windows.nil?
@@ -38,7 +38,7 @@ module Soba
             end
           end
 
-          logger.info("Cleanup completed: removed #{removed_count} windows")
+          logger.debug("Cleanup completed for #{session_name}: removed #{removed_count} windows")
         rescue StandardError => e
           logger.error("Unexpected error during cleanup: #{e.message}")
         end

--- a/spec/services/closed_issue_window_cleaner_spec.rb
+++ b/spec/services/closed_issue_window_cleaner_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Soba::Services::ClosedIssueWindowCleaner do
   let(:cleaner) { described_class.new(github_client: github_client, tmux_client: tmux_client, logger: logger) }
 
   describe '#clean' do
-    let(:session_name) { 'soba-workflow' }
+    let(:session_name) { 'soba-123' }
 
     before do
       # Mock the configuration for all tests
@@ -53,11 +53,11 @@ RSpec.describe Soba::Services::ClosedIssueWindowCleaner do
       it 'logs the cleanup actions' do
         cleaner.clean(session_name)
 
-        expect(logger).to have_received(:info).with('Cleaning up windows for closed issues...')
-        expect(logger).to have_received(:info).with('Found 3 closed issues')
+        expect(logger).to have_received(:debug).with('Cleaning up windows for closed issues in session: soba-123')
+        expect(logger).to have_received(:debug).with('Found 3 closed issues')
         expect(logger).to have_received(:info).with('Removed window: issue-42 (Issue #42: Fix bug)')
         expect(logger).to have_received(:info).with('Removed window: issue-43 (Issue #43: Add feature)')
-        expect(logger).to have_received(:info).with('Cleanup completed: removed 2 windows')
+        expect(logger).to have_received(:debug).with('Cleanup completed for soba-123: removed 2 windows')
       end
     end
 
@@ -77,8 +77,8 @@ RSpec.describe Soba::Services::ClosedIssueWindowCleaner do
       it 'logs that no cleanup is needed' do
         cleaner.clean(session_name)
 
-        expect(logger).to have_received(:info).with('Cleaning up windows for closed issues...')
-        expect(logger).to have_received(:info).with('No closed issues found')
+        expect(logger).to have_received(:debug).with('Cleaning up windows for closed issues in session: soba-123')
+        expect(logger).to have_received(:debug).with('No closed issues found')
       end
     end
 
@@ -102,9 +102,9 @@ RSpec.describe Soba::Services::ClosedIssueWindowCleaner do
       it 'logs that no windows need cleanup' do
         cleaner.clean(session_name)
 
-        expect(logger).to have_received(:info).with('Cleaning up windows for closed issues...')
-        expect(logger).to have_received(:info).with('Found 1 closed issues')
-        expect(logger).to have_received(:info).with('Cleanup completed: removed 0 windows')
+        expect(logger).to have_received(:debug).with('Cleaning up windows for closed issues in session: soba-123')
+        expect(logger).to have_received(:debug).with('Found 1 closed issues')
+        expect(logger).to have_received(:debug).with('Cleanup completed for soba-123: removed 0 windows')
       end
     end
 
@@ -123,7 +123,7 @@ RSpec.describe Soba::Services::ClosedIssueWindowCleaner do
         cleaner.clean(session_name)
 
         expect(logger).to have_received(:warn).with('Failed to remove window: issue-42')
-        expect(logger).to have_received(:info).with('Cleanup completed: removed 0 windows')
+        expect(logger).to have_received(:debug).with('Cleanup completed for soba-123: removed 0 windows')
       end
     end
 


### PR DESCRIPTION
## Summary
- TmuxSessionManagerから不要な個別セッション管理メソッドを削除
- リポジトリ単位のセッション管理に統一し、Issueごとのウィンドウ管理を維持
- ClosedIssueWindowCleanerのログレベルを最適化

## Changes
- `TmuxSessionManager`から以下のメソッドを削除:
  - `start_claude_session`
  - `stop_claude_session`
  - `get_session_status`
  - `attach_to_session`
  - `list_claude_sessions`
  - `cleanup_old_sessions`
  - `generate_session_name`
- `ClosedIssueWindowCleaner`のログレベルを最適化
  - 通常のクリーンアップ処理はdebugレベルに変更
  - 実際にウィンドウを削除した場合のみinfoレベルで出力
- ドキュメントを最新の実装に合わせて更新
- 不要になったテストコードを削除

## Test plan
- [x] RSpecテストが全てパス
- [x] RuboCopによるコード検査をパス
- [ ] 実環境でのtmuxセッション・ウィンドウ管理の動作確認

🤖 Generated with [Claude Code](https://claude.ai/code)