### PR TITLE
fix: reviseフェーズの設定不足を修正し「Phase configuration not defined」エラーを解消

### DIFF
--- a/lib/soba/configuration.rb
+++ b/lib/soba/configuration.rb
@@ -43,6 +43,11 @@ module Soba
         setting :options, default: []
         setting :parameter
       end
+      setting :revise do
+        setting :command
+        setting :options, default: []
+        setting :parameter
+      end
     end
 
     class << self
@@ -67,6 +72,9 @@ module Soba
           c.phase.review.command = nil
           c.phase.review.options = []
           c.phase.review.parameter = nil
+          c.phase.revise.command = nil
+          c.phase.revise.options = []
+          c.phase.revise.parameter = nil
         end
       end
 
@@ -155,6 +163,11 @@ module Soba
               c.phase.review.command = data.dig('phase', 'review', 'command')
               c.phase.review.options = data.dig('phase', 'review', 'options') || []
               c.phase.review.parameter = data.dig('phase', 'review', 'parameter')
+            end
+            if data['phase']['revise']
+              c.phase.revise.command = data.dig('phase', 'revise', 'command')
+              c.phase.revise.options = data.dig('phase', 'revise', 'options') || []
+              c.phase.revise.parameter = data.dig('phase', 'revise', 'parameter')
             end
           end
         end

--- a/lib/soba/infrastructure/lock_manager.rb
+++ b/lib/soba/infrastructure/lock_manager.rb
@@ -24,13 +24,15 @@ module Soba
         loop do
           # Check for stale lock
           if File.exist?(lock_file) && stale_threshold > 0
-            if Time.now - File.mtime(lock_file) > stale_threshold
-              # Remove stale lock
-              begin
+            begin
+              if Time.now - File.mtime(lock_file) > stale_threshold
+                # Remove stale lock
                 File.delete(lock_file)
-              rescue
-                nil
               end
+            rescue Errno::ENOENT
+              # File was deleted by another process, continue
+            rescue
+              # Other errors, ignore and continue
             end
           end
 

--- a/lib/soba/services/issue_processor.rb
+++ b/lib/soba/services/issue_processor.rb
@@ -179,6 +179,20 @@ module Soba
           else
             nil
           end
+        when :revise
+          actual_config = config.respond_to?(:config) ? config.config : config
+          revise_config = actual_config.phase.revise
+          values = revise_config.instance_variable_get(:@_values)
+
+          if values
+            OpenStruct.new(
+              command: values[:command],
+              options: values[:options],
+              parameter: values[:parameter]
+            )
+          else
+            nil
+          end
         else
           nil
         end

--- a/spec/commands/issue/watch_spec.rb
+++ b/spec/commands/issue/watch_spec.rb
@@ -81,6 +81,9 @@ RSpec.describe Soba::Commands::Issue::Watch do
         allow(phase_mock).to receive_message_chain(:review, :command=)
         allow(phase_mock).to receive_message_chain(:review, :options=)
         allow(phase_mock).to receive_message_chain(:review, :parameter=)
+        allow(phase_mock).to receive_message_chain(:revise, :command=)
+        allow(phase_mock).to receive_message_chain(:revise, :options=)
+        allow(phase_mock).to receive_message_chain(:revise, :parameter=)
 
         allow(Soba::Configuration).to receive(:config).and_return(
           double(


### PR DESCRIPTION
## Summary
- reviseフェーズで発生していた「Phase configuration not defined」エラーを修正
- Configurationクラスとget_phase_configメソッドにreviseフェーズの設定を追加
- LockManagerのマルチスレッド環境でのレースコンディションを修正

## 修正内容
### ✅ Configuration修正
- `lib/soba/configuration.rb` - reviseフェーズの設定を追加（46-50行、75-77行、167-171行）

### ✅ IssueProcessor修正  
- `lib/soba/services/issue_processor.rb` - get_phase_configメソッドにreviseケースを追加（182-195行）

### ✅ LockManager修正
- `lib/soba/infrastructure/lock_manager.rb` - File.mtimeのENOENTエラー対応（レースコンディション修正）

### ✅ テスト修正
- `spec/commands/issue/watch_spec.rb` - モックにreviseフェーズ対応を追加（84-86行）

## Test plan
- [x] bundle exec rspec - 全488テストが成功
- [x] revise統合テスト - 9テスト全て成功
- [x] IssueProcessorテスト - 11テスト全て成功  
- [x] LockManagerテスト - 18テスト全て成功

## 影響範囲
- Issue #84で発生したreviseフェーズのワークフロースキップ問題が解消
- reviseフェーズが正常に動作するようになる

🤖 Generated with [Claude Code](https://claude.ai/code)