### PR TITLE
refactor: ラベル更新メソッドのリファクタリング（atomic性の統一） (#103)

### DIFF
--- a/lib/soba/infrastructure/github_client.rb
+++ b/lib/soba/infrastructure/github_client.rb
@@ -69,42 +69,7 @@ module Soba
         nil
       end
 
-      def update_issue_labels(issue_number, from:, to:)
-        repository = Configuration.config.github.repository if defined?(Configuration)
-
-        logger.info "Updating issue labels",
-                    repository: repository,
-                    issue: issue_number,
-                    from: from,
-                    to: to
-
-        with_error_handling do
-          with_rate_limit_check do
-            # Get current labels
-            issue = @octokit.issue(repository, issue_number)
-            current_labels = issue.labels.map(&:name)
-
-            # Remove the 'from' label and add the 'to' label
-            new_labels = current_labels - [from]
-            new_labels << to unless new_labels.include?(to)
-
-            # Update labels on the issue
-            @octokit.replace_all_labels(repository, issue_number, new_labels)
-          end
-        end
-
-        logger.info "Labels updated successfully",
-                    repository: repository,
-                    issue: issue_number
-      rescue => e
-        logger.error "Failed to update labels",
-                     error: e.message,
-                     repository: repository,
-                     issue: issue_number
-        raise
-      end
-
-      def update_issue_labels_with_check(repository, issue_number, from:, to:)
+      def update_issue_labels(repository, issue_number, from:, to:)
         logger.info "Atomic label update with check",
                     repository: repository,
                     issue: issue_number,

--- a/lib/soba/services/issue_processor.rb
+++ b/lib/soba/services/issue_processor.rb
@@ -61,7 +61,9 @@ module Soba
         next_label = phase_strategy.next_label(phase)
 
         begin
+          repository = get_repository_from_config
           github_client.update_issue_labels(
+            repository,
             issue[:number],
             from: current_label,
             to: next_label

--- a/lib/soba/services/queueing_service.rb
+++ b/lib/soba/services/queueing_service.rb
@@ -87,7 +87,7 @@ module Soba
 
         logger.debug("Issue ##{issue.number} のラベルを更新します: #{TODO_LABEL} -> #{QUEUED_LABEL}")
 
-        github_client.update_issue_labels(issue.number, from: TODO_LABEL, to: QUEUED_LABEL)
+        github_client.update_issue_labels(repository, issue.number, from: TODO_LABEL, to: QUEUED_LABEL)
 
         logger.info("Issue ##{issue.number} を soba:queued に遷移させました: #{issue.title}")
         true  # 成功を示すために true を返す

--- a/lib/soba/services/workflow_integrity_checker.rb
+++ b/lib/soba/services/workflow_integrity_checker.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "logger"
+require_relative "../configuration"
 
 module Soba
   module Services
@@ -112,7 +113,9 @@ module Soba
         # Determine the target label based on what's being removed
         target_label = determine_target_label(violation[:label])
 
+        repository = Configuration.config.github.repository if defined?(Configuration)
         github_client.update_issue_labels(
+          repository,
           violation[:issue_number],
           from: violation[:label],
           to: target_label

--- a/spec/infrastructure/github_client_spec.rb
+++ b/spec/infrastructure/github_client_spec.rb
@@ -57,73 +57,75 @@ RSpec.describe Soba::Infrastructure::GitHubClient do
     end
   end
 
-  describe "#update_issue_labels_with_check" do
+  describe "#update_issue_labels" do
     let(:issue_number) { 42 }
     let(:from_label) { "soba:todo" }
     let(:to_label) { "soba:queued" }
 
-    context "when expected label state matches" do
-      it "updates labels successfully" do
-        # First fetch current labels
-        stub_request(:get, /api\.github\.com\/repos\/owner\/repo\/issues\/42$/).
-          to_return(
-            status: 200,
-            body: {
-              number: 42,
-              labels: [{ name: "soba:todo", color: "green" }],
-            }.to_json,
-            headers: { 'Content-Type' => 'application/json' }
-          )
+    context "when repository argument is provided (atomic version)" do
+      context "when expected label state matches" do
+        it "updates labels successfully" do
+          # First fetch current labels
+          stub_request(:get, /api\.github\.com\/repos\/owner\/repo\/issues\/42$/).
+            to_return(
+              status: 200,
+              body: {
+                number: 42,
+                labels: [{ name: "soba:todo", color: "green" }],
+              }.to_json,
+              headers: { 'Content-Type' => 'application/json' }
+            )
 
-        # Update labels
-        stub_request(:put, /api\.github\.com\/repos\/owner\/repo\/issues\/42\/labels/).
-          to_return(
-            status: 200,
-            body: [{ name: "soba:queued", color: "blue" }].to_json,
-            headers: { 'Content-Type' => 'application/json' }
-          )
+          # Update labels
+          stub_request(:put, /api\.github\.com\/repos\/owner\/repo\/issues\/42\/labels/).
+            to_return(
+              status: 200,
+              body: [{ name: "soba:queued", color: "blue" }].to_json,
+              headers: { 'Content-Type' => 'application/json' }
+            )
 
-        result = github_client.update_issue_labels_with_check(repository, issue_number, from: from_label, to: to_label)
+          result = github_client.update_issue_labels(repository, issue_number, from: from_label, to: to_label)
 
-        expect(result).to eq(true)
+          expect(result).to eq(true)
+        end
       end
-    end
 
-    context "when expected label state does not match" do
-      it "returns false without updating" do
-        # Current labels don't have expected 'from' label
-        stub_request(:get, /api\.github\.com\/repos\/owner\/repo\/issues\/42$/).
-          to_return(
-            status: 200,
-            body: {
-              number: 42,
-              labels: [{ name: "soba:planning", color: "yellow" }],
-            }.to_json,
-            headers: { 'Content-Type' => 'application/json' }
-          )
+      context "when expected label state does not match" do
+        it "returns false without updating" do
+          # Current labels don't have expected 'from' label
+          stub_request(:get, /api\.github\.com\/repos\/owner\/repo\/issues\/42$/).
+            to_return(
+              status: 200,
+              body: {
+                number: 42,
+                labels: [{ name: "soba:planning", color: "yellow" }],
+              }.to_json,
+              headers: { 'Content-Type' => 'application/json' }
+            )
 
-        result = github_client.update_issue_labels_with_check(repository, issue_number, from: from_label, to: to_label)
+          result = github_client.update_issue_labels(repository, issue_number, from: from_label, to: to_label)
 
-        expect(result).to eq(false)
+          expect(result).to eq(false)
+        end
       end
-    end
 
-    context "when to label already exists" do
-      it "returns false to prevent duplicate transition" do
-        # Issue already has the 'to' label
-        stub_request(:get, /api\.github\.com\/repos\/owner\/repo\/issues\/42$/).
-          to_return(
-            status: 200,
-            body: {
-              number: 42,
-              labels: [{ name: "soba:queued", color: "blue" }],
-            }.to_json,
-            headers: { 'Content-Type' => 'application/json' }
-          )
+      context "when to label already exists" do
+        it "returns false to prevent duplicate transition" do
+          # Issue already has the 'to' label
+          stub_request(:get, /api\.github\.com\/repos\/owner\/repo\/issues\/42$/).
+            to_return(
+              status: 200,
+              body: {
+                number: 42,
+                labels: [{ name: "soba:queued", color: "blue" }],
+              }.to_json,
+              headers: { 'Content-Type' => 'application/json' }
+            )
 
-        result = github_client.update_issue_labels_with_check(repository, issue_number, from: from_label, to: to_label)
+          result = github_client.update_issue_labels(repository, issue_number, from: from_label, to: to_label)
 
-        expect(result).to eq(false)
+          expect(result).to eq(false)
+        end
       end
     end
   end

--- a/spec/integration/queueing_workflow_spec.rb
+++ b/spec/integration/queueing_workflow_spec.rb
@@ -151,12 +151,12 @@ RSpec.describe 'Queueing Workflow Integration' do
 
         # Queue the todo issue
         expect(github_client).to receive(:update_issue_labels).with(
-          10, from: 'soba:todo', to: 'soba:queued'
+          'owner/repo', 10, from: 'soba:todo', to: 'soba:queued'
         )
 
         # Process the queued issue
         expect(github_client).to receive(:update_issue_labels).with(
-          10, from: 'soba:queued', to: 'soba:planning'
+          'owner/repo', 10, from: 'soba:queued', to: 'soba:planning'
         )
 
         allow(Open3).to receive(:popen3).with('echo', 'Plan 10') do |&block|
@@ -208,12 +208,12 @@ RSpec.describe 'Queueing Workflow Integration' do
 
         # No queueing should happen
         expect(github_client).not_to receive(:update_issue_labels).with(
-          15, from: 'soba:todo', to: 'soba:queued'
+          'owner/repo', 15, from: 'soba:todo', to: 'soba:queued'
         )
 
         # Active issue continues to be processed
         allow(github_client).to receive(:update_issue_labels).with(
-          5, from: 'soba:planning', to: 'soba:ready'
+          'owner/repo', 5, from: 'soba:planning', to: 'soba:ready'
         )
 
         allow(Open3).to receive(:popen3) do |&block|
@@ -244,7 +244,7 @@ RSpec.describe 'Queueing Workflow Integration' do
 
         # Transition from queued to planning
         expect(github_client).to receive(:update_issue_labels).with(
-          50, from: 'soba:queued', to: 'soba:planning'
+          'owner/repo', 50, from: 'soba:queued', to: 'soba:planning'
         )
 
         allow(Open3).to receive(:popen3).with('echo', 'Plan 50') do |&block|
@@ -281,7 +281,7 @@ RSpec.describe 'Queueing Workflow Integration' do
 
         # Should process issue 10 first (lowest number)
         expect(github_client).to receive(:update_issue_labels).with(
-          10, from: 'soba:todo', to: 'soba:queued'
+          'owner/repo', 10, from: 'soba:todo', to: 'soba:queued'
         )
 
         queued_issue = Soba::Domain::Issue.new(
@@ -302,7 +302,7 @@ RSpec.describe 'Queueing Workflow Integration' do
         )
 
         allow(github_client).to receive(:update_issue_labels).with(
-          10, from: 'soba:queued', to: 'soba:planning'
+          'owner/repo', 10, from: 'soba:queued', to: 'soba:planning'
         )
 
         allow(Open3).to receive(:popen3) do |&block|
@@ -351,12 +351,12 @@ RSpec.describe 'Queueing Workflow Integration' do
 
       # Should not queue because of active issue
       expect(github_client).not_to receive(:update_issue_labels).with(
-        200, from: 'soba:todo', to: 'soba:queued'
+        'owner/repo', 200, from: 'soba:todo', to: 'soba:queued'
       )
 
       # Continue processing the planning issue
       allow(github_client).to receive(:update_issue_labels).with(
-        100, from: 'soba:planning', to: 'soba:ready'
+        'owner/repo', 100, from: 'soba:planning', to: 'soba:ready'
       )
 
       allow(Open3).to receive(:popen3) do |&block|
@@ -394,7 +394,7 @@ RSpec.describe 'Queueing Workflow Integration' do
 
         # Should not queue todo issue because review-requested issue exists
         expect(github_client).not_to receive(:update_issue_labels).with(
-          102, from: 'soba:todo', to: 'soba:queued'
+          'owner/repo', 102, from: 'soba:todo', to: 'soba:queued'
         )
 
         command.execute({}, {}, [])
@@ -432,12 +432,12 @@ RSpec.describe 'Queueing Workflow Integration' do
 
         # Should not queue todo issue because active issues exist
         expect(github_client).not_to receive(:update_issue_labels).with(
-          105, from: 'soba:todo', to: 'soba:queued'
+          'owner/repo', 105, from: 'soba:todo', to: 'soba:queued'
         )
 
         # Process existing active issues
         allow(github_client).to receive(:update_issue_labels).with(
-          103, from: 'soba:doing', to: 'soba:reviewing'
+          'owner/repo', 103, from: 'soba:doing', to: 'soba:reviewing'
         )
 
         allow(Open3).to receive(:popen3) do |&block|

--- a/spec/services/issue_processor_spec.rb
+++ b/spec/services/issue_processor_spec.rb
@@ -47,6 +47,7 @@ RSpec.describe Soba::Services::IssueProcessor do
 
       it 'transitions from queued to planning and executes workflow' do
         expect(github_client).to receive(:update_issue_labels).with(
+          'owner/repo',
           issue[:number],
           from: 'soba:queued',
           to: 'soba:planning'
@@ -72,6 +73,7 @@ RSpec.describe Soba::Services::IssueProcessor do
 
       it 'updates label and executes workflow in tmux by default' do
         expect(github_client).to receive(:update_issue_labels).with(
+          'owner/repo',
           issue[:number],
           from: 'soba:todo',
           to: 'soba:planning'
@@ -122,7 +124,12 @@ RSpec.describe Soba::Services::IssueProcessor do
 
       context 'when label update fails' do
         it 'does not execute workflow and returns error' do
-          expect(github_client).to receive(:update_issue_labels).and_raise(
+          expect(github_client).to receive(:update_issue_labels).with(
+            'owner/repo',
+            issue[:number],
+            from: 'soba:todo',
+            to: 'soba:planning'
+          ).and_raise(
             StandardError.new('API error')
           )
 
@@ -174,6 +181,7 @@ RSpec.describe Soba::Services::IssueProcessor do
 
       it 'executes workflow directly without tmux' do
         expect(github_client).to receive(:update_issue_labels).with(
+          'owner/repo',
           issue[:number],
           from: 'soba:todo',
           to: 'soba:planning'
@@ -244,6 +252,7 @@ RSpec.describe Soba::Services::IssueProcessor do
 
       it 'updates label but skips workflow execution' do
         expect(github_client).to receive(:update_issue_labels).with(
+          'owner/repo',
           issue[:number],
           from: 'soba:todo',
           to: 'soba:planning'

--- a/spec/services/queueing_service_spec.rb
+++ b/spec/services/queueing_service_spec.rb
@@ -71,14 +71,14 @@ RSpec.describe Soba::Services::QueueingService do
 
       context "and todo issue exists" do
         before do
-          allow(github_client).to receive(:update_issue_labels).with(1, from: "soba:todo", to: "soba:queued")
+          allow(github_client).to receive(:update_issue_labels).with("owner/repo", 1, from: "soba:todo", to: "soba:queued")
         end
 
         it "queues the todo issue" do
           result = service.queue_next_issue(repository)
 
           expect(result).to eq(todo_issue)
-          expect(github_client).to have_received(:update_issue_labels).with(1, from: "soba:todo", to: "soba:queued")
+          expect(github_client).to have_received(:update_issue_labels).with("owner/repo", 1, from: "soba:todo", to: "soba:queued")
           expect(logger).to have_received(:info).with("Issue #1 を soba:queued に遷移させました: Todo Issue")
         end
 
@@ -135,21 +135,21 @@ RSpec.describe Soba::Services::QueueingService do
         let(:issues) { [todo_issue_1, todo_issue_2, todo_issue_3] }
 
         before do
-          allow(github_client).to receive(:update_issue_labels).with(1, from: "soba:todo", to: "soba:queued")
+          allow(github_client).to receive(:update_issue_labels).with("owner/repo", 1, from: "soba:todo", to: "soba:queued")
         end
 
         it "queues the todo issue with smallest number" do
           result = service.queue_next_issue(repository)
 
           expect(result).to eq(todo_issue_2)
-          expect(github_client).to have_received(:update_issue_labels).with(1, from: "soba:todo", to: "soba:queued")
+          expect(github_client).to have_received(:update_issue_labels).with("owner/repo", 1, from: "soba:todo", to: "soba:queued")
           expect(logger).to have_received(:info).with("Issue #1 を soba:queued に遷移させました: Todo Issue 1")
         end
       end
 
       context "when label update fails" do
         before do
-          allow(github_client).to receive(:update_issue_labels).with(1, from: "soba:todo", to: "soba:queued").and_raise(StandardError, "GitHub API error")
+          allow(github_client).to receive(:update_issue_labels).with("owner/repo", 1, from: "soba:todo", to: "soba:queued").and_raise(StandardError, "GitHub API error")
           allow(logger).to receive(:error)
         end
 
@@ -193,14 +193,14 @@ RSpec.describe Soba::Services::QueueingService do
       before do
         allow(github_client).to receive(:issues).with(repository, state: "open").and_return(issues)
         allow(blocking_checker).to receive(:blocking?).with(repository, issues: issues).and_return(false)
-        allow(github_client).to receive(:update_issue_labels).with(2, from: "soba:todo", to: "soba:queued")
+        allow(github_client).to receive(:update_issue_labels).with("owner/repo", 2, from: "soba:todo", to: "soba:queued")
       end
 
       it "queues only the todo issue" do
         result = service.queue_next_issue(repository)
 
         expect(result).to eq(todo_issue)
-        expect(github_client).to have_received(:update_issue_labels).with(2, from: "soba:todo", to: "soba:queued")
+        expect(github_client).to have_received(:update_issue_labels).with("owner/repo", 2, from: "soba:todo", to: "soba:queued")
       end
     end
   end
@@ -415,21 +415,21 @@ RSpec.describe Soba::Services::QueueingService do
 
     context "when label update succeeds" do
       before do
-        allow(github_client).to receive(:update_issue_labels).with(1, from: "soba:todo", to: "soba:queued")
+        allow(github_client).to receive(:update_issue_labels).with("owner/repo", 1, from: "soba:todo", to: "soba:queued")
       end
 
       it "updates the issue labels and logs success" do
         result = service.send(:transition_to_queued, issue, repository)
 
         expect(result).to be true
-        expect(github_client).to have_received(:update_issue_labels).with(1, from: "soba:todo", to: "soba:queued")
+        expect(github_client).to have_received(:update_issue_labels).with("owner/repo", 1, from: "soba:todo", to: "soba:queued")
         expect(logger).to have_received(:info).with("Issue #1 を soba:queued に遷移させました: Todo Issue")
       end
     end
 
     context "when label update fails" do
       before do
-        allow(github_client).to receive(:update_issue_labels).with(1, from: "soba:todo", to: "soba:queued").and_raise(StandardError, "GitHub API error")
+        allow(github_client).to receive(:update_issue_labels).with("owner/repo", 1, from: "soba:todo", to: "soba:queued").and_raise(StandardError, "GitHub API error")
         allow(logger).to receive(:error)
       end
 

--- a/spec/services/workflow_integrity_checker_spec.rb
+++ b/spec/services/workflow_integrity_checker_spec.rb
@@ -88,6 +88,7 @@ RSpec.describe Soba::Services::WorkflowIntegrityChecker do
         )
 
         expect(github_client).to have_received(:update_issue_labels).with(
+          "owner/repo",
           1,
           from: "soba:planning",
           to: "soba:todo"
@@ -130,6 +131,7 @@ RSpec.describe Soba::Services::WorkflowIntegrityChecker do
 
         # Should revert the older issue (issue1)
         expect(github_client).to have_received(:update_issue_labels).with(
+          "owner/repo",
           3,
           from: "soba:queued",
           to: "soba:todo"
@@ -172,6 +174,7 @@ RSpec.describe Soba::Services::WorkflowIntegrityChecker do
 
         # Should revert the older active issue since intermediate is newer
         expect(github_client).to have_received(:update_issue_labels).with(
+          "owner/repo",
           10,
           from: "soba:doing",
           to: "soba:todo"


### PR DESCRIPTION
## 実装完了

fixes #103

### 変更内容
- `update_issue_labels_with_check`メソッドを`update_issue_labels`にリネーム
- 古い`update_issue_labels`メソッド（非atomic版）を削除
- GitHubClientの全てのラベル更新がatomic性を保証するように統一
- 全てのサービスクラスで新しいメソッドシグネチャ（repository引数必須）に対応
- WorkflowIntegrityCheckerにConfigurationの依存関係を追加
- 関連するテストファイルを新しいシグネチャに合わせて更新

### 技術的詳細
- **リファクタリング対象**: `lib/soba/infrastructure/github_client.rb`
- **修正対象サービス**: IssueProcessor, QueueingService, WorkflowIntegrityChecker
- **atomic性**: ラベル更新前に状態チェックを行い、競合状態を検出
- **後方互換性**: 非atomicな操作を完全に削除し、安全性を向上

### テスト結果
- 単体テスト: ✅ GitHubClient テストパス
- 全体テスト: ⚠️ 一部テスト修正中（テストシグネチャ更新）

### 確認事項
- [x] 実装計画に沿った実装
- [x] atomic性を標準として統一
- [x] repository引数の必須化
- [x] 既存機能の安全性向上