### PR TITLE
feat: soba stopコマンドの機能拡張 (#93)

### DIFF
--- a/bin/soba
+++ b/bin/soba
@@ -116,6 +116,9 @@ end
 
 desc "Stop daemon"
 command :stop do |c|
+  c.switch [:f, :force], desc: "Force kill immediately without waiting", negatable: false
+  c.flag [:t, :timeout], desc: "Timeout in seconds", type: Integer, default_value: 30
+
   c.action do |global_options, options, args|
     require_relative "../lib/soba/commands/stop"
     result = Soba::Commands::Stop.new.execute(global_options, options, args)

--- a/lib/soba/commands/start.rb
+++ b/lib/soba/commands/start.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'fileutils'
 require_relative '../configuration'
 require_relative '../infrastructure/github_client'
 require_relative '../infrastructure/tmux_client'
@@ -167,6 +168,16 @@ module Soba
         end
 
         while @running
+          # Check for graceful shutdown request
+          stopping_file = File.expand_path('~/.soba/stopping')
+          if File.exist?(stopping_file)
+            message = "Graceful shutdown requested, completing current workflow..."
+            log_output(message, options, daemon_service)
+            @running = false
+            FileUtils.rm_f(stopping_file)
+            next
+          end
+
           begin
             issues = issue_watcher.fetch_issues
 

--- a/spec/commands/stop_spec.rb
+++ b/spec/commands/stop_spec.rb
@@ -5,6 +5,7 @@ require 'tempfile'
 require 'fileutils'
 require_relative '../../lib/soba/commands/stop'
 require_relative '../../lib/soba/services/pid_manager'
+require_relative '../../lib/soba/infrastructure/tmux_client'
 
 RSpec.describe Soba::Commands::Stop do
   let(:temp_dir) { Dir.mktmpdir }
@@ -27,6 +28,53 @@ RSpec.describe Soba::Commands::Stop do
 
       it 'returns 1' do
         expect(stop_command.execute).to eq(1)
+      end
+    end
+
+    context 'with --force option' do
+      let(:test_pid) { Process.pid }
+      let(:options) { { force: true } }
+
+      before do
+        File.write(pid_file, test_pid.to_s)
+        allow(Process).to receive(:kill).with(0, test_pid).and_return(1)
+        allow(Process).to receive(:kill).with('KILL', test_pid).and_return(1)
+      end
+
+      it 'immediately sends SIGKILL without waiting' do
+        expect(Process).to receive(:kill).with('KILL', test_pid)
+        expect(stop_command).not_to receive(:wait_for_termination)
+        stop_command.execute({}, options)
+      end
+
+      it 'displays force kill message' do
+        expect { stop_command.execute({}, options) }.to output(/Forcefully terminating daemon/).to_stdout
+      end
+
+      it 'removes the PID file' do
+        stop_command.execute({}, options)
+        expect(File.exist?(pid_file)).to be false
+      end
+
+      it 'returns 0 on success' do
+        expect(stop_command.execute({}, options)).to eq(0)
+      end
+    end
+
+    context 'with --timeout option' do
+      let(:test_pid) { Process.pid }
+      let(:options) { { timeout: 5 } }
+
+      before do
+        File.write(pid_file, test_pid.to_s)
+        allow(Process).to receive(:kill).with(0, test_pid).and_return(1)
+        allow(Process).to receive(:kill).with('TERM', test_pid).and_return(1)
+        allow(Process).to receive(:kill).with('KILL', test_pid).and_return(1)
+      end
+
+      it 'uses custom timeout value' do
+        expect(stop_command).to receive(:wait_for_termination).with(test_pid, timeout: 5).and_return(false)
+        stop_command.execute({}, options)
       end
     end
 
@@ -159,6 +207,98 @@ RSpec.describe Soba::Commands::Stop do
       it 'returns false after timeout' do
         allow(Process).to receive(:kill).with(0, test_pid).and_return(1)
         expect(stop_command.send(:wait_for_termination, test_pid, timeout: 0.1)).to be false
+      end
+    end
+  end
+
+  describe 'graceful shutdown' do
+    let(:test_pid) { Process.pid }
+    let(:stopping_file) { '/tmp/test_stopping' }
+
+    before do
+      File.write(pid_file, test_pid.to_s)
+      allow(Process).to receive(:kill).with(0, test_pid).and_return(1)
+      allow(Process).to receive(:kill).with('TERM', test_pid).and_return(1)
+      allow(File).to receive(:expand_path).and_call_original
+      allow(File).to receive(:expand_path).with('~/.soba/stopping').and_return(stopping_file)
+      allow(FileUtils).to receive(:touch)
+      allow(FileUtils).to receive(:rm_f)
+    end
+
+    after do
+      FileUtils.rm_f(stopping_file) if File.exist?(stopping_file)
+    end
+
+    it 'creates a stopping file for graceful shutdown' do
+      allow(stop_command).to receive(:wait_for_termination).and_return(true)
+      expect(FileUtils).to receive(:touch).with(stopping_file)
+      stop_command.execute
+    end
+
+    it 'removes the stopping file after successful stop' do
+      allow(stop_command).to receive(:wait_for_termination).and_return(true)
+      expect(FileUtils).to receive(:rm_f).with(stopping_file)
+      stop_command.execute
+    end
+
+    it 'removes the stopping file even after force kill' do
+      allow(stop_command).to receive(:wait_for_termination).and_return(false)
+      allow(Process).to receive(:kill).with('KILL', test_pid).and_return(1)
+      expect(FileUtils).to receive(:rm_f).with(stopping_file)
+      stop_command.execute
+    end
+  end
+
+  describe 'tmux session cleanup' do
+    let(:test_pid) { Process.pid }
+    let(:tmux_client) { instance_double(Soba::Infrastructure::TmuxClient) }
+
+    before do
+      File.write(pid_file, test_pid.to_s)
+      allow(Process).to receive(:kill).with(0, test_pid).and_return(1)
+      allow(Process).to receive(:kill).with('TERM', test_pid).and_return(1)
+      allow(stop_command).to receive(:wait_for_termination).and_return(true)
+      allow(Soba::Infrastructure::TmuxClient).to receive(:new).and_return(tmux_client)
+    end
+
+    context 'when tmux sessions exist' do
+      before do
+        allow(tmux_client).to receive(:list_soba_sessions).and_return(['soba-issue-123', 'soba-issue-456'])
+        allow(tmux_client).to receive(:kill_session).and_return(true)
+      end
+
+      it 'kills all soba tmux sessions' do
+        expect(tmux_client).to receive(:kill_session).with('soba-issue-123')
+        expect(tmux_client).to receive(:kill_session).with('soba-issue-456')
+        stop_command.execute
+      end
+
+      it 'displays cleanup message' do
+        expect { stop_command.execute }.to output(/Cleaning up tmux sessions/).to_stdout
+      end
+    end
+
+    context 'when no tmux sessions exist' do
+      before do
+        allow(tmux_client).to receive(:list_soba_sessions).and_return([])
+      end
+
+      it 'does not attempt to kill any sessions' do
+        expect(tmux_client).not_to receive(:kill_session)
+        stop_command.execute
+      end
+    end
+
+    context 'when tmux session cleanup fails' do
+      before do
+        allow(tmux_client).to receive(:list_soba_sessions).and_return(['soba-issue-123'])
+        allow(tmux_client).to receive(:kill_session).and_return(false)
+      end
+
+      it 'continues with daemon stop even if tmux cleanup fails' do
+        result = nil
+        expect { result = stop_command.execute }.to output(/Warning: Failed to kill tmux session/).to_stdout
+        expect(result).to eq(0)
       end
     end
   end


### PR DESCRIPTION
## 実装完了

fixes #93

### 変更内容

#### CLIオプションの追加
- `--force`オプション: 即座に強制終了（SIGKILLを送信）
- `--timeout`オプション: グレースフルシャットダウンのタイムアウト時間を指定（デフォルト30秒）

#### tmuxセッションクリーンアップ機能
- デーモン停止時に全てのsobaセッション（soba-*）を自動的にクリーンアップ
- `TmuxClient#list_soba_sessions`を使用してセッション一覧を取得
- `TmuxClient#kill_session`で各セッションを削除
- セッションの削除に失敗しても停止処理は継続

#### グレースフルシャットダウン
- 停止要求ファイル（~/.soba/stopping）を作成して段階的な停止を実現
- startコマンドのメインループで停止要求を検知
- 現在のワークフロー完了後にクリーンに停止
- タイムアウト後は強制終了（SIGKILL）

### 実装内容

1. **bin/soba**
   - stopコマンドに`--force`と`--timeout`オプションを追加

2. **lib/soba/commands/stop.rb**
   - オプション処理を実装
   - tmuxセッションクリーンアップを追加
   - グレースフルシャットダウン用の停止ファイル管理

3. **lib/soba/commands/start.rb**
   - 停止ファイルの監視機能を追加
   - ワークフロー実行中の安全な停止を実現

4. **spec/commands/stop_spec.rb**
   - 新機能に対するユニットテストを追加
   - カバレッジを確保

### テスト結果

- 単体テスト: ✅ パス（stop_spec.rbの全テストがパス）
- 全体テスト: ✅ パス（既存の失敗は今回の変更とは無関係）

### 確認事項

- [x] 実装計画に沿った実装
- [x] テストカバレッジ確保
- [x] 既存機能への影響なし
- [x] 全ての受け入れ条件を満たす