### PR TITLE
fix: キューイング制御でアクティブなIssue処理中に新規キューイングを防ぐ (#108)

### DIFF
--- a/lib/soba/services/workflow_blocking_checker.rb
+++ b/lib/soba/services/workflow_blocking_checker.rb
@@ -8,6 +8,7 @@ module Soba
       ACTIVE_LABELS = %w(
         soba:queued
         soba:planning
+        soba:ready
         soba:doing
         soba:reviewing
         soba:revising
@@ -16,11 +17,6 @@ module Soba
       INTERMEDIATE_LABELS = %w(
         soba:review-requested
         soba:requires-changes
-      ).freeze
-
-      WAITING_LABELS = %w(
-        soba:ready
-        soba:review-requested
       ).freeze
 
       attr_reader :github_client, :logger

--- a/spec/services/workflow_blocking_checker_spec.rb
+++ b/spec/services/workflow_blocking_checker_spec.rb
@@ -106,9 +106,9 @@ RSpec.describe Soba::Services::WorkflowBlockingChecker do
       end
       let(:issues) { [ready_issue] }
 
-      it "returns false" do
+      it "returns true (active state blocks new issues)" do
         result = checker.blocking?(repository, issues: issues)
-        expect(result).to be false
+        expect(result).to be true
       end
     end
 


### PR DESCRIPTION
## 実装完了

fixes #108

### 変更内容
- `WorkflowBlockingChecker`の`ACTIVE_LABELS`に`soba:ready`を追加
- `soba:ready`ラベルを持つIssueが存在する場合、新規キューイングをブロック
- 未使用の`WAITING_LABELS`定数を削除
- 関連テストケースを更新

### テスト結果
- 単体テスト: ✅ パス（WorkflowBlockingChecker）
- 統合テスト: ✅ パス（QueueingService）
- 全体テスト: ✅ パス（411例、0失敗）

### 確認事項
- [x] 実装計画に沿った実装
- [x] テストカバレッジ確保
- [x] 既存機能への影響なし

### 詳細
この修正により、`soba:ready`および`soba:review-requested`ラベルを持つIssueが存在する場合、新しいIssueのキューイングがブロックされるようになりました。これにより、ワークフローの仕様通り「同時に1つのIssueのみがアクティブ処理される」原則が守られます。