### PR TITLE
feat: tmuxセッションのPIDベース分離による独立管理の実現

### DIFF
--- a/lib/soba/services/tmux_session_manager.rb
+++ b/lib/soba/services/tmux_session_manager.rb
@@ -18,8 +18,8 @@ module Soba
 
         return { success: false, error: 'Repository configuration not found' } if repository.blank?
 
-        # Convert repository name to session-safe format
-        session_name = "soba-#{repository.gsub(/[\/._]/, '-')}"
+        # Convert repository name to session-safe format with PID
+        session_name = generate_session_name(repository)
 
         if @tmux_client.session_exists?(session_name)
           { success: true, session_name: session_name, created: false }
@@ -37,8 +37,8 @@ module Soba
 
         return { success: false, error: 'Repository configuration not found' } if repository.blank?
 
-        # Convert repository name to session-safe format
-        session_name = "soba-#{repository.gsub(/[\/._]/, '-')}"
+        # Convert repository name to session-safe format with PID
+        session_name = generate_session_name(repository)
 
         if @tmux_client.session_exists?(session_name)
           { success: true, session_name: session_name, exists: true }
@@ -156,7 +156,7 @@ module Soba
       end
 
       def find_issue_window(repository_name, issue_number)
-        session_name = "soba-#{repository_name.gsub(/[\/._]/, '-')}"
+        session_name = generate_session_name(repository_name)
         window_name = "issue-#{issue_number}"
 
         if @tmux_client.session_exists?(session_name) && @tmux_client.window_exists?(session_name, window_name)
@@ -167,7 +167,7 @@ module Soba
       end
 
       def list_issue_windows(repository_name)
-        session_name = "soba-#{repository_name.gsub(/[\/._]/, '-')}"
+        session_name = generate_session_name(repository_name)
 
         return [] unless @tmux_client.session_exists?(session_name)
 
@@ -197,6 +197,11 @@ module Soba
       end
 
       private
+
+      # Generate session name with PID for process isolation
+      def generate_session_name(repository)
+        "soba-#{repository.gsub(/[\/._]/, '-')}-#{Process.pid}"
+      end
 
       def fetch_issue_title(repository_name, issue_number)
         # This is a placeholder - actual implementation would use GitHub API

--- a/spec/services/tmux_session_manager_spec.rb
+++ b/spec/services/tmux_session_manager_spec.rb
@@ -15,10 +15,11 @@ RSpec.describe Soba::Services::TmuxSessionManager do
       allow(Soba::Configuration).to receive(:config).and_return(
         double(github: double(repository: 'owner/repo-name'))
       )
+      allow(Process).to receive(:pid).and_return(12345)
     end
 
-    it 'creates a new repository session if not exists' do
-      session_name = 'soba-owner-repo-name'
+    it 'creates a new repository session with PID if not exists' do
+      session_name = 'soba-owner-repo-name-12345'
       allow(tmux_client).to receive(:session_exists?).with(session_name).and_return(false)
       allow(tmux_client).to receive(:create_session).with(session_name).and_return(true)
 
@@ -31,7 +32,7 @@ RSpec.describe Soba::Services::TmuxSessionManager do
     end
 
     it 'returns existing repository session if exists' do
-      session_name = 'soba-owner-repo-name'
+      session_name = 'soba-owner-repo-name-12345'
       allow(tmux_client).to receive(:session_exists?).with(session_name).and_return(true)
       allow(tmux_client).to receive(:create_session)
 
@@ -47,7 +48,7 @@ RSpec.describe Soba::Services::TmuxSessionManager do
       allow(Soba::Configuration).to receive(:config).and_return(
         double(github: double(repository: 'owner/repo.name-with_special'))
       )
-      session_name = 'soba-owner-repo-name-with-special'
+      session_name = 'soba-owner-repo-name-with-special-12345'
       allow(tmux_client).to receive(:session_exists?).with(session_name).and_return(false)
       allow(tmux_client).to receive(:create_session).with(session_name).and_return(true)
 
@@ -74,7 +75,7 @@ RSpec.describe Soba::Services::TmuxSessionManager do
   end
 
   describe '#create_issue_window' do
-    let(:session_name) { 'soba-owner-repo' }
+    let(:session_name) { 'soba-owner-repo-12345' }
     let(:issue_number) { 42 }
 
     before do
@@ -202,10 +203,11 @@ RSpec.describe Soba::Services::TmuxSessionManager do
       allow(Soba::Configuration).to receive(:config).and_return(
         double(github: double(repository: 'owner/repo-name'))
       )
+      allow(Process).to receive(:pid).and_return(12345)
     end
 
     it 'returns session name when repository session exists' do
-      session_name = 'soba-owner-repo-name'
+      session_name = 'soba-owner-repo-name-12345'
       allow(tmux_client).to receive(:session_exists?).with(session_name).and_return(true)
 
       result = manager.find_repository_session
@@ -216,7 +218,7 @@ RSpec.describe Soba::Services::TmuxSessionManager do
     end
 
     it 'returns not exists when repository session does not exist' do
-      session_name = 'soba-owner-repo-name'
+      session_name = 'soba-owner-repo-name-12345'
       allow(tmux_client).to receive(:session_exists?).with(session_name).and_return(false)
 
       result = manager.find_repository_session
@@ -230,7 +232,7 @@ RSpec.describe Soba::Services::TmuxSessionManager do
       allow(Soba::Configuration).to receive(:config).and_return(
         double(github: double(repository: 'owner/repo.name-with_special'))
       )
-      session_name = 'soba-owner-repo-name-with-special'
+      session_name = 'soba-owner-repo-name-with-special-12345'
       allow(tmux_client).to receive(:session_exists?).with(session_name).and_return(true)
 
       result = manager.find_repository_session
@@ -257,7 +259,7 @@ RSpec.describe Soba::Services::TmuxSessionManager do
   end
 
   describe '#create_phase_pane' do
-    let(:session_name) { 'soba-owner-repo' }
+    let(:session_name) { 'soba-owner-repo-12345' }
     let(:window_name) { 'issue-42' }
     let(:phase) { 'planning' }
 


### PR DESCRIPTION
## Summary
- tmuxセッション名にPID（プロセスID）を追加し、複数プロセス間でのセッション分離を実現
- TmuxSessionManagerで一元的なセッション名生成機能を実装（形式: soba-{repository}-{PID}）
- Stopコマンドを修正し、現在のプロセスのtmuxセッションのみをクリーンアップするように変更
- 関連するすべてのテストを新しいセッション命名形式に対応するよう更新

## Test plan
- [ ] 複数のsobaプロセスを並行実行し、それぞれが独立したtmuxセッションを作成することを確認
- [ ] stopコマンド実行時に、現在のプロセスのセッションのみが削除されることを確認
- [ ] 他のプロセスのtmuxセッションが影響を受けないことを確認
- [ ] リポジトリ名に特殊文字が含まれる場合でも正常に動作することを確認
- [ ] 既存のテストスイートがすべてパスすることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)