### PR TITLE
feat: gemの名前を sobaから soba-cli に変更 (#116)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-# Specify your gem's dependencies in soba.gemspec
+# Specify your gem's dependencies in soba-cli.gemspec
 gemspec
 
 # Additional development dependencies that might be needed for specific CI/local dev environments

--- a/README.md
+++ b/README.md
@@ -1,11 +1,18 @@
-# soba
+# soba-cli
 
 GitHub IssueとClaude Codeを連携させる自律的ワークフロー実行CLIツール
+
+## インストール
+
+```bash
+# gemとしてインストール
+gem install soba-cli
+```
 
 ## セットアップ
 
 ```bash
-# 依存関係のインストール
+# 開発用：依存関係のインストール
 bundle install
 
 # Git hooksの設定（Rubocop自動チェック）

--- a/soba-cli.gemspec
+++ b/soba-cli.gemspec
@@ -3,7 +3,7 @@
 require_relative "lib/soba/version"
 
 Gem::Specification.new do |spec|
-  spec.name = "soba"
+  spec.name = "soba-cli"
   spec.version = Soba::VERSION
   spec.authors = ["douhashi"]
   spec.email = ["soba@douhashi.dev"]

--- a/spec/gemspec_spec.rb
+++ b/spec/gemspec_spec.rb
@@ -3,12 +3,12 @@
 require 'English'
 require 'spec_helper'
 
-RSpec.describe 'soba.gemspec' do
-  let(:gemspec_path) { File.expand_path('../soba.gemspec', __dir__) }
+RSpec.describe 'soba-cli.gemspec' do
+  let(:gemspec_path) { File.expand_path('../soba-cli.gemspec', __dir__) }
   let(:gemspec) { Gem::Specification.load(gemspec_path) }
 
   describe 'gemspecファイルの存在' do
-    it 'soba.gemspecファイルが存在すること' do
+    it 'soba-cli.gemspecファイルが存在すること' do
       expect(File.exist?(gemspec_path)).to be true
     end
 
@@ -19,7 +19,7 @@ RSpec.describe 'soba.gemspec' do
 
   describe 'メタデータ' do
     it '必須のメタデータが定義されていること' do
-      expect(gemspec.name).to eq('soba')
+      expect(gemspec.name).to eq('soba-cli')
       expect(gemspec.version).not_to be_nil
       expect(gemspec.summary).not_to be_empty
       expect(gemspec.description).not_to be_empty
@@ -108,12 +108,12 @@ RSpec.describe 'soba.gemspec' do
   describe 'gemビルド' do
     it 'gem buildコマンドが成功すること' do
       Dir.chdir(File.dirname(gemspec_path)) do
-        output = `gem build soba.gemspec 2>&1`
+        output = `gem build soba-cli.gemspec 2>&1`
         expect($CHILD_STATUS).to be_success, "gem build failed: #{output}"
         expect(output).to include('Successfully built')
 
         # クリーンアップ
-        gem_file = Dir.glob('soba-*.gem').first
+        gem_file = Dir.glob('soba-cli-*.gem').first
         if gem_file && File.exist?(gem_file)
           File.delete(gem_file)
         end


### PR DESCRIPTION
## 実装完了

fixes #116

### 変更内容
- gemspecファイル名を `soba.gemspec` から `soba-cli.gemspec` に変更
- gem名を `soba` から `soba-cli` に変更
- 実行ファイル名 `soba` は維持（ユーザビリティを保持）
- README.mdにgem installコマンドを追加
- Gemfileのコメントを更新
- テストファイルの参照も更新

### 実装計画との対応
✅ gemspec更新（soba.gemspec → soba-cli.gemspec）
✅ Gemfile更新（コメントの参照パス更新）
✅ README更新（インストール手順の追加）
✅ テスト実行と検証（全テストがパス）
✅ gemビルドと動作確認（gem buildコマンドが成功）

### テスト結果
- 単体テスト: ✅ パス（643 examples, 1 failure, 17 pending → 修正後全パス）
- 全体テスト: ✅ パス
- Rubocop: ✅ パス（no offenses detected）
- gem build: ✅ 成功（soba-cli-0.1.0.gem が正常にビルド）

### 確認事項
- [x] 実装計画に沿った実装
- [x] テストカバレッジ確保
- [x] 既存機能への影響なし
- [x] gem名変更後も `soba` コマンドで実行可能
- [x] `gem install soba-cli` でインストール可能になる