### PR TITLE
feat: Slack通知機能の修正と改善 (#148)

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,14 @@ workflow:
   # Command delay for tmux panes in seconds (default: 3)
   tmux_command_delay: 3
 
+# Slack notifications
+slack:
+  # Webhook URL for Slack notifications
+  # Get your webhook URL from: https://api.slack.com/messaging/webhooks
+  webhook_url: ${SLACK_WEBHOOK_URL}
+  # Enable notifications for phase starts (default: false)
+  notifications_enabled: false
+
 # Git settings
 git:
   # Base path for git worktrees

--- a/README_ja.md
+++ b/README_ja.md
@@ -114,6 +114,14 @@ workflow:
   # tmuxペインへのコマンド遅延（秒）（デフォルト: 3）
   tmux_command_delay: 3
 
+# Slack通知設定
+slack:
+  # Slack通知用のWebhook URL
+  # Webhook URLの取得方法: https://api.slack.com/messaging/webhooks
+  webhook_url: ${SLACK_WEBHOOK_URL}
+  # フェーズ開始時の通知を有効化（デフォルト: false）
+  notifications_enabled: false
+
 # Git設定
 git:
   # git worktreeのベースパス

--- a/lib/soba/configuration.rb
+++ b/lib/soba/configuration.rb
@@ -214,9 +214,13 @@ module Soba
             closed_issue_cleanup_interval: 300
             # Delay in seconds before sending commands to new tmux panes/windows (default: 3)
             tmux_command_delay: 3
+
+          slack:
+            # Slack webhook URL for sending notifications
+            # Can use environment variable: ${SLACK_WEBHOOK_URL}
+            webhook_url: ${SLACK_WEBHOOK_URL}
             # Enable Slack notifications for phase starts (default: false)
-            # Requires SLACK_WEBHOOK_URL environment variable
-            slack_notifications_enabled: false
+            notifications_enabled: false
 
           git:
             # Base path for git worktrees

--- a/lib/soba/services/slack_notifier.rb
+++ b/lib/soba/services/slack_notifier.rb
@@ -13,16 +13,23 @@ module Soba
       def notify_phase_start(issue_data)
         return false unless enabled?
 
+        logger.debug "Starting Slack notification for issue ##{issue_data[:number]}, phase: #{issue_data[:phase]}"
+
         begin
-          response = send_notification(build_message(issue_data))
+          message = build_message(issue_data)
+          logger.debug "Sending notification to Slack webhook"
+
+          response = send_notification(message)
+
           if response.success?
+            logger.debug "Slack notification sent successfully (HTTP #{response.status})"
             true
           else
-            logger.error("Failed to send Slack notification: HTTP #{response.status}")
+            logger.warn("Failed to send Slack notification: HTTP #{response.status}")
             false
           end
         rescue StandardError => e
-          logger.error("Error sending Slack notification: #{e.message}")
+          logger.warn("Error sending Slack notification: #{e.message}")
           false
         end
       end

--- a/lib/soba/services/workflow_executor.rb
+++ b/lib/soba/services/workflow_executor.rb
@@ -167,16 +167,24 @@ module Soba
       private
 
       def send_slack_notification(issue_number, issue_title, phase_name)
-        return unless ConfigLoader.config.workflow.slack_notifications_enabled
+        return unless Configuration.config.slack.notifications_enabled
 
-        notifier = SlackNotifier.from_env
-        return unless notifier.enabled?
+        notifier = SlackNotifier.from_config
+        return unless notifier&.enabled?
 
-        notifier.notify_phase_start(
+        Soba.logger.debug "Sending Slack notification for phase '#{phase_name}' of issue ##{issue_number}"
+
+        result = notifier.notify_phase_start(
           number: issue_number,
           title: issue_title || "Issue ##{issue_number}",
           phase: phase_name
         )
+
+        if result
+          Soba.logger.debug "Successfully sent Slack notification for phase '#{phase_name}'"
+        else
+          Soba.logger.debug "Failed to send Slack notification for phase '#{phase_name}'"
+        end
       rescue StandardError => e
         Soba.logger.warn "Failed to send Slack notification: #{e.message}"
       end

--- a/spec/services/workflow_executor_spec.rb
+++ b/spec/services/workflow_executor_spec.rb
@@ -728,13 +728,13 @@ RSpec.describe Soba::Services::WorkflowExecutor do
       context 'when Slack notifications are enabled' do
         before do
           config = double('config')
-          workflow = double('workflow', slack_notifications_enabled: true)
-          allow(config).to receive(:workflow).and_return(workflow)
-          allow(Soba::ConfigLoader).to receive(:config).and_return(config)
+          slack = double('slack', notifications_enabled: true)
+          allow(config).to receive(:slack).and_return(slack)
+          allow(Soba::Configuration).to receive(:config).and_return(config)
         end
 
         it 'sends notification when phase starts' do
-          expect(Soba::Services::SlackNotifier).to receive(:from_env).and_return(slack_notifier)
+          expect(Soba::Services::SlackNotifier).to receive(:from_config).and_return(slack_notifier)
           expect(slack_notifier).to receive(:enabled?).and_return(true)
           expect(slack_notifier).to receive(:notify_phase_start).with(
             hash_including(
@@ -763,7 +763,7 @@ RSpec.describe Soba::Services::WorkflowExecutor do
         end
 
         it 'continues execution even if notification fails' do
-          expect(Soba::Services::SlackNotifier).to receive(:from_env).and_return(slack_notifier)
+          expect(Soba::Services::SlackNotifier).to receive(:from_config).and_return(slack_notifier)
           expect(slack_notifier).to receive(:enabled?).and_return(true)
           expect(slack_notifier).to receive(:notify_phase_start).and_return(false)
 
@@ -787,7 +787,7 @@ RSpec.describe Soba::Services::WorkflowExecutor do
         end
 
         it 'does not send notification if webhook URL is not configured' do
-          expect(Soba::Services::SlackNotifier).to receive(:from_env).and_return(slack_notifier)
+          expect(Soba::Services::SlackNotifier).to receive(:from_config).and_return(slack_notifier)
           expect(slack_notifier).to receive(:enabled?).and_return(false)
           expect(slack_notifier).not_to receive(:notify_phase_start)
 
@@ -814,9 +814,9 @@ RSpec.describe Soba::Services::WorkflowExecutor do
       context 'when Slack notifications are disabled' do
         before do
           config = double('config')
-          workflow = double('workflow', slack_notifications_enabled: false)
-          allow(config).to receive(:workflow).and_return(workflow)
-          allow(Soba::ConfigLoader).to receive(:config).and_return(config)
+          slack = double('slack', notifications_enabled: false)
+          allow(config).to receive(:slack).and_return(slack)
+          allow(Soba::Configuration).to receive(:config).and_return(config)
         end
 
         it 'does not send notification' do

--- a/spec/soba/services/slack_notifier_spec.rb
+++ b/spec/soba/services/slack_notifier_spec.rb
@@ -47,6 +47,12 @@ RSpec.describe Soba::Services::SlackNotifier do
       end
 
       it "sends a notification successfully" do
+        logger = instance_double(Logger)
+        allow(notifier).to receive(:logger).and_return(logger)
+        expect(logger).to receive(:debug).with(/Starting Slack notification/)
+        expect(logger).to receive(:debug).with(/Sending notification to Slack webhook/)
+        expect(logger).to receive(:debug).with(/Slack notification sent successfully/)
+
         expect(connection_stub).to receive(:post) do |url, payload|
           expect(url).to eq(webhook_url)
 
@@ -99,10 +105,12 @@ RSpec.describe Soba::Services::SlackNotifier do
           expect(result).to be false
         end
 
-        it "logs an error message" do
+        it "logs a warning message" do
           logger = instance_double(Logger)
           allow(notifier).to receive(:logger).and_return(logger)
-          expect(logger).to receive(:error).with(/Failed to send Slack notification/)
+          expect(logger).to receive(:debug).with(/Starting Slack notification/)
+          expect(logger).to receive(:debug).with(/Sending notification to Slack webhook/)
+          expect(logger).to receive(:warn).with(/Failed to send Slack notification/)
 
           notifier.notify_phase_start(issue_data)
         end
@@ -121,7 +129,9 @@ RSpec.describe Soba::Services::SlackNotifier do
         it "logs the error" do
           logger = instance_double(Logger)
           allow(notifier).to receive(:logger).and_return(logger)
-          expect(logger).to receive(:error).with(/Error sending Slack notification/)
+          expect(logger).to receive(:debug).with(/Starting Slack notification/)
+          expect(logger).to receive(:debug).with(/Sending notification to Slack webhook/)
+          expect(logger).to receive(:warn).with(/Error sending Slack notification/)
 
           notifier.notify_phase_start(issue_data)
         end
@@ -204,6 +214,97 @@ RSpec.describe Soba::Services::SlackNotifier do
       it "creates an instance with nil webhook_url" do
         notifier = described_class.from_env
         expect(notifier.instance_variable_get(:@webhook_url)).to be_nil
+      end
+    end
+  end
+
+  describe ".from_config" do
+    context "when slack notifications are enabled in config" do
+      let(:config) do
+        double('config',
+          slack: double('slack',
+            notifications_enabled: true,
+            webhook_url: webhook_url))
+      end
+
+      before do
+        allow(Soba::Configuration).to receive(:config).and_return(config)
+      end
+
+      it "creates an instance with webhook_url from config" do
+        notifier = described_class.from_config
+        expect(notifier).to be_a(described_class)
+        expect(notifier.instance_variable_get(:@webhook_url)).to eq(webhook_url)
+      end
+
+      context "with environment variable reference in config" do
+        let(:config) do
+          double('config',
+            slack: double('slack',
+              notifications_enabled: true,
+              webhook_url: "${CUSTOM_SLACK_WEBHOOK}"))
+        end
+
+        before do
+          ENV["CUSTOM_SLACK_WEBHOOK"] = webhook_url
+        end
+
+        after do
+          ENV.delete("CUSTOM_SLACK_WEBHOOK")
+        end
+
+        it "expands environment variable reference" do
+          notifier = described_class.from_config
+          expect(notifier.instance_variable_get(:@webhook_url)).to eq(webhook_url)
+        end
+      end
+
+      context "with unset environment variable reference" do
+        let(:config) do
+          double('config',
+            slack: double('slack',
+              notifications_enabled: true,
+              webhook_url: "${UNSET_VAR}"))
+        end
+
+        it "creates instance with nil webhook_url" do
+          notifier = described_class.from_config
+          expect(notifier.instance_variable_get(:@webhook_url)).to be_nil
+        end
+      end
+    end
+
+    context "when slack notifications are disabled in config" do
+      let(:config) do
+        double('config',
+          slack: double('slack',
+            notifications_enabled: false,
+            webhook_url: webhook_url))
+      end
+
+      before do
+        allow(Soba::Configuration).to receive(:config).and_return(config)
+      end
+
+      it "returns nil" do
+        expect(described_class.from_config).to be_nil
+      end
+    end
+
+    context "when config does not have slack settings" do
+      let(:config) do
+        double('config',
+          slack: double('slack',
+            notifications_enabled: nil,
+            webhook_url: nil))
+      end
+
+      before do
+        allow(Soba::Configuration).to receive(:config).and_return(config)
+      end
+
+      it "returns nil" do
+        expect(described_class.from_config).to be_nil
       end
     end
   end


### PR DESCRIPTION
## 実装完了

fixes #148

### 変更内容
- WorkflowExecutorでConfiguration.configを使用するよう修正
- SlackNotifier.from_configメソッドを使用して設定ファイルベースの通知に対応
- デバッグレベルのログを追加してSlack通知の送信状況を記録
- README.mdとREADME_ja.mdにSlack設定の説明を追加
- デフォルト設定ファイルにSlack設定セクションを追加

### テスト結果
- 単体テスト: ✅ パス
- 全体テスト: ✅ パス

### 確認事項
- [x] 実装計画に沿った実装
- [x] テストカバレッジ確保
- [x] 既存機能への影響なし
- [x] Rubocop検証パス