### PR TITLE
fix: gemとしてインストールした際の実行エラーを修正

### DIFF
--- a/bin/soba
+++ b/bin/soba
@@ -1,9 +1,15 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-require "bundler/setup"
+# Load from gem if installed, otherwise use local development setup
+begin
+  require "soba"
+rescue LoadError
+  require "bundler/setup"
+  require_relative "../lib/soba"
+end
+
 require "gli"
-require_relative "../lib/soba"
 
 include GLI::App
 


### PR DESCRIPTION
## 概要
gemとしてインストールした際に発生する実行エラーを修正しました。

## 問題
`gem install soba-cli` でインストール後に `soba` コマンドを実行すると以下のエラーが発生:
```
can't find gem soba-cli (>= 0.a) with executable soba (Gem::GemNotFoundException)
```

## 原因
`bin/soba` ファイルが `require "bundler/setup"` を使用していたため、gem環境（Bundler外）で動作しない

## 解決策
bin/sobaファイルのrequire処理を以下のように修正：
- gemとしてインストールされた場合: `require "soba"` を使用
- ローカル開発環境: 従来通り `bundler/setup` と相対パスでの読み込みを使用
- LoadErrorをキャッチして適切な読み込み方法を自動選択

## テスト手順
- [x] ローカル開発環境での動作確認 (`bundle exec ruby bin/soba --version`)
- [x] gemビルドとインストール (`gem build` → `gem install`)
- [x] インストール後の動作確認 (`soba --version`)

🤖 Generated with [Claude Code](https://claude.ai/code)